### PR TITLE
[FEATURE] HistoryRepository 구현

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/model/remote/response/DetailDataResponse.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/model/remote/response/DetailDataResponse.kt
@@ -1,14 +1,31 @@
 package co.kr.woowahan_banchan.data.model.remote.response
 
+import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import com.google.gson.annotations.SerializedName
 
 data class DetailDataResponse(
-    @SerializedName("top_image") val topImageUrl : String,
-    @SerializedName("thumb_images") val thumbnailUrls : List<String>,
-    @SerializedName("product_description") val productDescription : String,
-    val point : String,
-    @SerializedName("delivery_info") val deliveryInfo : String,
-    @SerializedName("delivery_fee") val deliveryFee : String,
-    val prices : List<String>,
-    @SerializedName("detail_section") val detailSection : List<String>
-)
+    @SerializedName("top_image") val topImageUrl: String,
+    @SerializedName("thumb_images") val thumbnailUrls: List<String>,
+    @SerializedName("product_description") val productDescription: String,
+    val point: String,
+    @SerializedName("delivery_info") val deliveryInfo: String,
+    @SerializedName("delivery_fee") val deliveryFee: String,
+    val prices: List<String>,
+    @SerializedName("detail_section") val detailSection: List<String>
+) {
+    fun toHistoryItem(hash: String, title: String, time: Long, isAdded: Boolean): HistoryItem {
+        return HistoryItem(
+            hash,
+            this.topImageUrl,
+            title,
+            if (prices.size == 1) null else prices.first().toPriceInt(),
+            if (prices.size == 1) prices.first().toPriceInt() else prices.last().toPriceInt(),
+            time,
+            isAdded
+        )
+    }
+
+    private fun String.toPriceInt(): Int {
+        return this.replace("원", "").replace(",", "").toInt()
+    }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package co.kr.woowahan_banchan.data.repository
+
+import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
+import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
+import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
+import co.kr.woowahan_banchan.domain.repository.HistoryRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class HistoryRepositoryImpl @Inject constructor(
+    private val historyDataSource: HistoryDataSource,
+    private val cartDataSource: CartDataSource,
+    private val detailDataSource: DetailDataSource,
+    private val coroutineDispatcher: CoroutineDispatcher
+) : HistoryRepository {
+    override fun getHistories(previewMode: Boolean): Flow<List<HistoryItem>> {
+        return combine(
+            historyDataSource.getItems(),
+            cartDataSource.getItems()
+        ) { historyDtoList, cartDtoList ->
+            Pair(historyDtoList, cartDtoList)
+        }.map { pair ->
+            val historyDtoList = pair.first
+            val cartDtoList = pair.second
+            historyDtoList.mapNotNull { historyDto ->
+                val apiResult = detailDataSource.getDetail(historyDto.hash)
+                when (apiResult.isSuccess) {
+                    true -> {
+                        apiResult.getOrThrow().data.toHistoryItem(
+                            historyDto.hash,
+                            historyDto.name,
+                            historyDto.time,
+                            cartDtoList.find { it.hash == historyDto.hash } != null
+                        )
+                    }
+                    false -> {
+                        null
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/di/RepositoryModule.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/di/RepositoryModule.kt
@@ -1,9 +1,13 @@
 package co.kr.woowahan_banchan.di
 
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
+import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.best.BestDataSource
+import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
 import co.kr.woowahan_banchan.data.repository.DishRepositoryImpl
+import co.kr.woowahan_banchan.data.repository.HistoryRepositoryImpl
 import co.kr.woowahan_banchan.domain.repository.DishRepository
+import co.kr.woowahan_banchan.domain.repository.HistoryRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,4 +25,14 @@ object RepositoryModule {
         bestDataSource: BestDataSource,
         @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
     ): DishRepository = DishRepositoryImpl(cartDataSource, bestDataSource, coroutineDispatcher)
+
+    @Provides
+    @Singleton
+    fun provideHistoryRepository(
+        historyDataSource: HistoryDataSource,
+        cartDataSource: CartDataSource,
+        detailDataSource: DetailDataSource,
+        @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
+    ): HistoryRepository =
+        HistoryRepositoryImpl(historyDataSource, cartDataSource, detailDataSource, coroutineDispatcher)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/entity/history/HistoryItem.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/entity/history/HistoryItem.kt
@@ -1,0 +1,11 @@
+package co.kr.woowahan_banchan.domain.entity.history
+
+data class HistoryItem(
+    val detailHash: String,
+    val imageUrl: String,
+    val title: String,
+    val nPrice: Int?,
+    val sPrice: Int,
+    val time: Long,
+    val isAdded: Boolean
+)

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
@@ -1,0 +1,8 @@
+package co.kr.woowahan_banchan.domain.repository
+
+import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
+import kotlinx.coroutines.flow.Flow
+
+interface HistoryRepository {
+    fun getHistories(previewMode: Boolean): Flow<List<HistoryItem>>
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #18 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] HistoryRepository 구현
- 최근 조회 내역 리스트 + 장바구니 리스트를 combine한 뒤, 리스트를 순회하며 hash 값으로 상세 정보 조회 API를 호출해 UI에 보여줄 타입의 리스트로 만들었습니다.
- 추가로, 장바구니에 담는 경우는 앱 여기저기서 반복해 쓰이는 것 같아 DishRepository에서 메서드를 하나 만들고 이를 UseCase로 분리해 재사용하는 것을 제안드립니다.
- Thank you Skipancho

close #18 