### PR TITLE
[FEATURE] OrderDao, OrderItemDao 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/OrderDao.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/OrderDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface OrderDao {
     @Query("SELECT * FROM `ORDER`")
-    fun getItems(): Flow<List<OrderDto>>
+    suspend fun getItems(): List<OrderDto>
 
     @Insert
     suspend fun insertItem(item: OrderDto): Long

--- a/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/OrderItemDao.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/OrderItemDao.kt
@@ -8,8 +8,11 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface OrderItemDao {
-    @Query("SELECT * FROM ORDER_ITEM")
-    fun getItems(): Flow<List<OrderItemDto>>
+    @Query("SELECT * FROM ORDER_ITEM WHERE order_id LIKE (:orderId)")
+    suspend fun getItems(orderId: Int): List<OrderItemDto>
+
+    @Query("SELECT COUNT(id) FROM ORDER_ITEM WHERE order_id LIKE (:orderId)")
+    suspend fun getItemCount(orderId: Int): Int
 
     @Insert
     suspend fun insertItems(items: List<OrderItemDto>)

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSource.kt
@@ -4,6 +4,6 @@ import co.kr.woowahan_banchan.data.model.local.OrderDto
 import kotlinx.coroutines.flow.Flow
 
 interface OrderDataSource {
-    fun getItems(): Flow<List<OrderDto>>
+    suspend fun getItems(): Result<List<OrderDto>>
     suspend fun insertItem(item: OrderDto): Result<Long>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
@@ -14,12 +14,12 @@ class OrderDataSourceImpl @Inject constructor(
     private val orderDao: OrderDao,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : OrderDataSource {
-    override fun getItems(): Flow<List<OrderDto>> =
-        orderDao.getItems()
-            .catch { exception ->
-                Timber.e(exception)
-                emit(listOf())
-            }.flowOn(coroutineDispatcher)
+    override suspend fun getItems(): Result<List<OrderDto>> =
+        withContext(coroutineDispatcher) {
+            runCatching {
+                orderDao.getItems()
+            }
+        }
 
     override suspend fun insertItem(item: OrderDto): Result<Long> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSource.kt
@@ -1,9 +1,9 @@
 package co.kr.woowahan_banchan.data.datasource.local.orderitem
 
 import co.kr.woowahan_banchan.data.model.local.OrderItemDto
-import kotlinx.coroutines.flow.Flow
 
 interface OrderItemDataSource {
-    fun getItems(): Flow<List<OrderItemDto>>
+    suspend fun getItems(orderId: Int): Result<List<OrderItemDto>>
+    suspend fun getItemCount(orderId: Int): Result<Int>
     suspend fun insertItems(items: List<OrderItemDto>): Result<Unit>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
@@ -15,12 +15,19 @@ class OrderItemDataSourceImpl @Inject constructor(
     private val orderItemDao: OrderItemDao,
     private val coroutineDispatcher: CoroutineDispatcher
 ): OrderItemDataSource {
-    override fun getItems(): Flow<List<OrderItemDto>> =
-        orderItemDao.getItems()
-            .catch { exception ->
-                Timber.e(exception)
-                emit(listOf())
-            }.flowOn(coroutineDispatcher)
+    override suspend fun getItems(orderId: Int): Result<List<OrderItemDto>> =
+        withContext(coroutineDispatcher) {
+            runCatching {
+                orderItemDao.getItems(orderId)
+            }
+        }
+
+    override suspend fun getItemCount(orderId: Int): Result<Int> =
+        withContext(coroutineDispatcher) {
+            runCatching {
+                orderItemDao.getItemCount(orderId)
+            }
+        }
 
     override suspend fun insertItems(items: List<OrderItemDto>): Result<Unit> =
         withContext(coroutineDispatcher) {


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #26 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
구현하면서 생각해보니 잘못된 부분이 있어 일부 수정했습니다.
- [x] OrderDao, OrderItemDao가 Flow가 아닌 Result를 리턴하도록 수정
- Flow로 리턴해서 얻을 수 있는 장점이 없다고 판단하였습니다.
- [x] OrderItemDao의 getItems 메서드에 orderId 파라미터 추가
- [x] OrderItemDao에 getItemCount(orderId) 메서드를 추가해 해당 orderId를 갖고 있는 아이템 개수를 반환할 수 있게 구현