### PR TITLE
[FEATURE] 장바구니 추가 기능 구현

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/CartDao.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/CartDao.kt
@@ -17,4 +17,7 @@ interface CartDao {
 
     @Query("DELETE FROM CART WHERE hash in (:ids)")
     suspend fun deleteItems(ids: List<String>)
+
+    @Query("SELECT amount FROM CART where hash LIKE (:hash)")
+    suspend fun getAmount(hash: String): Int
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/CartDao.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/database/dao/CartDao.kt
@@ -18,6 +18,6 @@ interface CartDao {
     @Query("DELETE FROM CART WHERE hash in (:ids)")
     suspend fun deleteItems(ids: List<String>)
 
-    @Query("SELECT amount FROM CART where hash LIKE (:hash)")
+    @Query("SELECT amount FROM CART WHERE hash LIKE (:hash)")
     suspend fun getAmount(hash: String): Int
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSource.kt
@@ -7,4 +7,5 @@ interface CartDataSource {
     fun getItems(): Flow<List<CartDto>>
     suspend fun insertOrUpdateItems(items: List<CartDto>): Result<Unit>
     suspend fun deleteItems(ids: List<String>): Result<Unit>
+    suspend fun getAmount(hash: String): Result<Int>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
@@ -34,4 +34,11 @@ class CartDataSourceImpl @Inject constructor(
                 cartDao.deleteItems(ids)
             }
         }
+
+    override suspend fun getAmount(hash: String): Result<Int> =
+        withContext(coroutineDispatcher) {
+            runCatching {
+                cartDao.getAmount(hash)
+            }
+        }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
@@ -10,8 +10,9 @@ class CartRepositoryImpl @Inject constructor(
     private val cartDataSource: CartDataSource
 ) : CartRepository {
     override suspend fun addToCart(hash: String, amount: Int, name: String) {
+        val originalAmount = cartDataSource.getAmount(hash).getOrDefault(0)
         cartDataSource.insertOrUpdateItems(
-            listOf(CartDto(hash, amount, true, Date().time, name))
+            listOf(CartDto(hash, amount + originalAmount, true, Date().time, name))
         )
     }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/CartAddUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/CartAddUseCase.kt
@@ -1,0 +1,13 @@
+package co.kr.woowahan_banchan.domain.usecase
+
+import co.kr.woowahan_banchan.domain.repository.CartRepository
+import javax.inject.Inject
+
+class CartAddUseCase @Inject constructor(
+    private val cartRepository: CartRepository
+) {
+    suspend operator fun invoke(hash: String, amount: Int, name: String): Result<Unit> =
+        runCatching {
+            cartRepository.addToCart(hash, amount, name)
+        }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
@@ -122,19 +122,6 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
     private fun showTotalPrice(amount: Int, price: Int) {
         val totalPrice = amount * price
         binding.tvTotalPriceValue.text = totalPrice.toPriceFormat() + "원"
-        binding.btnOrder.text =
-            if (totalPrice >= 10000) {
-                "주문하기"
-            } else {
-                "최소주문금액을 확인해주세요"
-            }
-        binding.btnOrder.isClickable = totalPrice >= 10000
-        binding.btnOrder.backgroundTintList =
-            if (totalPrice >= 10000) {
-                ColorStateList.valueOf(getColor(R.color.primary_f9ba70))
-            } else {
-                ColorStateList.valueOf(getColor(R.color.primary_fcdcb7))
-            }
     }
 
     private fun addDetailImages(imageUrls: List<String>) {

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
@@ -3,27 +3,41 @@ package co.kr.woowahan_banchan.presentation.viewmodel.productdetail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.kr.woowahan_banchan.domain.entity.detail.DishInfo
+import co.kr.woowahan_banchan.domain.usecase.CartAddUseCase
 import co.kr.woowahan_banchan.domain.usecase.ProductDetailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ProductDetailViewModel @Inject constructor(
-    private val productDetailUseCase: ProductDetailUseCase
+    private val productDetailUseCase: ProductDetailUseCase,
+    private val cartAddUseCase: CartAddUseCase
 ) : ViewModel() {
-    private val _dishInfo = MutableStateFlow<UiState>(UiState.Init)
-    val dishInfo: StateFlow<UiState> get() = _dishInfo
+    private val _dishInfo = MutableStateFlow<UiState<DishInfo>>(UiState.Init)
+    val dishInfo: StateFlow<UiState<DishInfo>> get() = _dishInfo
     private val _amount = MutableStateFlow<Int>(1)
     val amount: StateFlow<Int> get() = _amount
+    private val _isAddSuccess = MutableSharedFlow<Boolean>()
+    val isAddSuccess: SharedFlow<Boolean> get() = _isAddSuccess
 
     fun fetchUiState(hash: String) {
         viewModelScope.launch {
             productDetailUseCase(hash)
                 .onSuccess { _dishInfo.value = UiState.Success(it) }
                 .onFailure { _dishInfo.value = UiState.Error(it.message) }
+        }
+    }
+
+    fun addToCart(hash: String, name: String) {
+        viewModelScope.launch {
+            cartAddUseCase(hash, amount.value, name)
+                .onSuccess { _isAddSuccess.emit(true) }
+                .onFailure { _isAddSuccess.emit(false) }
         }
     }
 
@@ -37,9 +51,9 @@ class ProductDetailViewModel @Inject constructor(
         }
     }
 
-    sealed class UiState {
-        object Init : UiState()
-        data class Success(val dishInfo: DishInfo) : UiState()
-        data class Error(val message: String?) : UiState()
+    sealed class UiState<out T> {
+        object Init : UiState<Nothing>()
+        data class Success<out T>(val data: T) : UiState<T>()
+        data class Error(val message: String?) : UiState<Nothing>()
     }
 }


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #42 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 장바구니 추가 기능 구현

## ✔ MUST CHECK

기능을 구현한 뒤 App Inspection으로 확인하던 중 이런 상황이 발생하더라구요, Skipancho.
만일 내가 쭈꾸미 한돈 제육볶음을 1개를 장바구니에 추가한 뒤, (현재 DB상으로 쭈꾸미 한돈 제육볶음이 1개 있는 상황)
이어서 쭈꾸미 한돈 제육볶음을 2개를 장바구니에 추가한다면,
이 상황에서 나는 쭈꾸미 한돈 제육볶음 3개가 장바구니에 있어야 맞다고 생각합니다.
그런데 지금의 경우는 단순히 insertOrUpdateItems() 메서드를 호출하기 때문에 저 아이템이 이미 DB에 있어 insert가 아닌 update가 수행되어 실제로 장바구니에는 쭈꾸미 한돈 제육볶음 2개가 장바구니에 있습니다.
그래서 Dao에 특정 hash를 갖는 아이템의 수량을 가져오는 메서드를 추가한 뒤, Repository에서 다음과 같은 순서로 진행됩니다.
1. DB에 이 hash를 갖는 아이템이 몇 개 있는지 가져옴 (이를 편의상 `originalAmount` 라고 하겠습니다.)
2. 현재 내가 장바구니에 추가하고자 하는 아이템의 수량 (이를 편의상 `amount` 라고 하겠습니다.) 에 `originalAmount` 를 더한 값으로 DB에 갱신합니다.
3. 만일 이 hash를 가진 아이템이 DB에 없다면, getOrDefault 메서드를 사용해 `originalAmount` 는 0이 됩니다.
4. 즉, DB에 insertOrUpdateItem() 메서드를 호출하는 경우에는 `originalAmount + amount` 만큼의 수량이 담기게 됩니다.

새로 추가된 로직이기 때문에 이 부분까지 확인해 주시면 좋을 것 같군, Skipancho