### PR TITLE
[FEATURE] ExtraExtension, ArgumentExtension 추가

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/decoration/OrderListItemDecoration.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/decoration/OrderListItemDecoration.kt
@@ -1,4 +1,4 @@
-package co.kr.woowahan_banchan.util
+package co.kr.woowahan_banchan.presentation.decoration
 
 import android.graphics.Canvas
 import android.graphics.Paint

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
@@ -43,7 +43,7 @@ class OrderListFragment : BaseFragment<FragmentOrderListBinding>() {
                 5.dpToPx(),
                 5.dpToPx(),
                 1.dpToPx(),
-                requireContext().resources.getColor(R.color.grayscale_dddddd, null)
+                requireContext().resources.getColor(R.color.grayscale_aaaaaa, null)
             )
         )
         binding.rvOrderList.adapter = orderListAdapter

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
@@ -14,7 +14,7 @@ import co.kr.woowahan_banchan.presentation.ui.base.BaseFragment
 import co.kr.woowahan_banchan.presentation.ui.order.OrderActivity
 import co.kr.woowahan_banchan.presentation.viewmodel.UiState
 import co.kr.woowahan_banchan.presentation.viewmodel.order.OrderListViewModel
-import co.kr.woowahan_banchan.util.OrderListItemDecoration
+import co.kr.woowahan_banchan.presentation.decoration.OrderListItemDecoration
 import co.kr.woowahan_banchan.util.dpToPx
 import co.kr.woowahan_banchan.util.shortToast
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/co/kr/woowahan_banchan/util/ArgumentExtension.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/util/ArgumentExtension.kt
@@ -1,0 +1,25 @@
+package co.kr.woowahan_banchan.util
+
+import android.os.Parcelable
+import androidx.fragment.app.Fragment
+import kotlin.properties.ReadOnlyProperty
+
+fun intArgs() = ReadOnlyProperty<Fragment, Int> { thisRef, property ->
+    thisRef.requireArguments().getInt(property.name)
+}
+
+fun longArgs() = ReadOnlyProperty<Fragment, Long> { thisRef, property ->
+    thisRef.requireArguments().getLong(property.name)
+}
+
+fun boolArgs() = ReadOnlyProperty<Fragment, Boolean> { thisRef, property ->
+    thisRef.requireArguments().getBoolean(property.name)
+}
+
+fun stringArgs() = ReadOnlyProperty<Fragment, String> { thisRef, property ->
+    thisRef.requireArguments().getString(property.name, "")
+}
+
+fun <P : Parcelable> parcelableExtra() = ReadOnlyProperty<Fragment, P?> { thisRef, property ->
+    thisRef.requireArguments().getParcelable(property.name)
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/util/ExtraExtension.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/util/ExtraExtension.kt
@@ -1,0 +1,38 @@
+package co.kr.woowahan_banchan.util
+
+import android.app.Activity
+import android.os.Parcelable
+import kotlin.properties.ReadOnlyProperty
+
+fun intExtra(defaultValue: Int = -1) = ReadOnlyProperty<Activity, Int> { thisRef, property ->
+    thisRef.intent.extras?.getInt(
+        property.name,
+        defaultValue
+    ) ?: defaultValue
+}
+
+fun longExtra(defaultValue: Long = -1) = ReadOnlyProperty<Activity, Long> { thisRef, property ->
+    thisRef.intent.extras?.getLong(
+        property.name,
+        defaultValue
+    ) ?: defaultValue
+}
+
+fun boolExtra(defaultValue: Boolean = false) =
+    ReadOnlyProperty<Activity, Boolean> { thisRef, property ->
+        thisRef.intent.extras?.getBoolean(
+            property.name,
+            defaultValue
+        ) ?: defaultValue
+    }
+
+fun stringExtra(defaultValue: String? = null) =
+    ReadOnlyProperty<Activity, String?> { thisRef, property ->
+        if (defaultValue == null) thisRef.intent.extras?.getString(property.name)
+        else thisRef.intent.extras?.getString(property.name, defaultValue)
+    }
+
+fun <P : Parcelable> parcelableExtra(defaultValue: P? = null) =
+    ReadOnlyProperty<Activity, P?> { thisRef, property ->
+        thisRef.intent.extras?.getParcelable<P>(property.name) ?: defaultValue
+    }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="grayscale_ffffff">#FFFFFF</color>
     <color name="grayscale_f5f5f7">#F5F5F7</color>
     <color name="grayscale_dcdcdc">#DCDCDC</color>
+    <color name="grayscale_aaaaaa">#AAAAAA</color>
 
     <color name="primary_f46700">#F46700</color>
     <color name="primary_f9ba70">#F9BA70</color>


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #58 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] ItemDecoration 패키지 이동
- [x] divider 색상이 눈에 잘 띄지 않아 `#AAAAAA` 색상 새로 추가
### Extension 추가
- [x] ExtraExtension 추가
- [x] ArgumentExtension 추가

이봐, @Skipancho !
자네는 Activity나 Fragment 간 데이터를 주고받을 때, Extra나 Argument를 사용하지 않나 ?
나는 매번 Activity와 Fragment 클래스 내 변수로 저 Extra나 Argument에서 꺼내와 값을 할당할 변수를 만드는 것을 매우 번거롭다고 생각해왔네.

예시를 들자면, 자네가 만들고있는 홈 화면에서 반찬을 누르면 내가 만든 반찬 상세 화면에 hash를 `putExtra("HASH", hash)` 처럼 넘겨줘야 하잖아?
나는 그럼 이럴 때마다 Activity 안에 `private var hash: String = ""` 이렇게 선언해두고
onCreate에서 `hash = intent.getStringExtra("HASH") ?: ""` 이렇게 해왔단 말일세 ...

불편하지 않은가? 그래서 가져왔다네. ExtraExtension과 ArgumentExtension !!

원리는 이렇다네. 집중해 Skipancho.

kotlin.properties의 ReadOnlyProperty를 가져와보겠네.

``` kotlin
/**
 * Base interface that can be used for implementing property delegates of read-only properties.
 *
 * This is provided only for convenience; you don't have to extend this interface
 * as long as your property delegate has methods with the same signatures.
 *
 * @param T the type of object which owns the delegated property.
 * @param V the type of the property value.
 */
public fun interface ReadOnlyProperty<in T, out V> {
    /**
     * Returns the value of the property for the given object.
     * @param thisRef the object for which the value is requested.
     * @param property the metadata for the property.
     * @return the property value.
     */
    public operator fun getValue(thisRef: T, property: KProperty<*>): V
}
```

T는 delegated property를 소유한 객체의 타입, V는 property value의 타입일세. 
그리고 thisRef: T는 value를 요청받은 객체이고, property: KProperty<*>는 프로퍼티에 대한 메타데이터일세.
나는 이것을 활용할 것이야.

``` kotlin
fun intExtra(defaultValue: Int = -1) = ReadOnlyProperty<Activity, Int> { thisRef, property ->
    thisRef.intent.extras?.getInt(
        property.name,
        defaultValue
    ) ?: defaultValue
}
```

어떤가, 뭔가 느낌이 오나? (왔으면 좋겠군)
해당 property.name으로 넘겨준 Int값이 있으면 그 값을 가져오고, 그렇지 않으면 위의 함수에서는 defaultValue를 리턴하게 될 것이야.

그럼 코드에서는 어떻게 쓰는가? 아주 쉽네.

``` kotlin
private val hash by stringExtra("")
```

이렇게 Activity에 선언하면 끝일세.

단, 우리가 이 Extension을 지금이라도 도입하기로 했다면 주의할 점이 있는데, 그건 바로 현재 이미 연결되어있는 MainActivity - ProductDetailActivity 간 property.name을 통일해야 한다는 것이야.
아마 이건 다음 주 화요일 출근 때 맞춰봐도 될 것일세.

그럼, 행운을 빌지.

- From Your Friend, Iceman 🧊