### PR TITLE
[FEATURE] 12_OrderDetail 화면 기초 기능 구현

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderDetailUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderDetailUseCase.kt
@@ -1,0 +1,14 @@
+package co.kr.woowahan_banchan.domain.usecase
+
+import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderItem
+import co.kr.woowahan_banchan.domain.repository.OrderHistoryRepository
+import javax.inject.Inject
+
+class OrderDetailUseCase @Inject constructor(
+    private val orderHistoryRepository: OrderHistoryRepository
+) {
+    suspend operator fun invoke(orderId: Long): Result<List<OrderItem>> =
+        orderHistoryRepository.getOrderReceipt(orderId)?.let {
+            Result.success(it)
+        } ?: Result.failure(Exception("문제가 발생했습니다"))
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/OrderActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/OrderActivity.kt
@@ -28,16 +28,26 @@ class OrderActivity : BaseActivity<ActivityOrderBinding>() {
     fun setToolbar(fragmentType: FragmentType) {
         when (fragmentType) {
             FragmentType.ORDER_LIST -> {
-                binding.tbToolbar.title = "OrderList"
-                binding.tbToolbar.setNavigationIcon(R.drawable.ic_arrow_left)
-                binding.tbToolbar.setNavigationOnClickListener { finish() }
+                with(binding.tbToolbar) {
+                    this.title = "OrderList"
+                    this.setNavigationIcon(R.drawable.ic_arrow_left)
+                    this.setNavigationOnClickListener { finish() }
+                }
+            }
+            FragmentType.ORDER_DETAIL -> {
+                with(binding.tbToolbar) {
+                    this.title = ""
+                    this.setNavigationIcon(R.drawable.ic_arrow_left)
+                    this.setNavigationOnClickListener { supportFragmentManager.popBackStack() }
+                }
+
             }
         }
     }
 
     companion object {
         enum class FragmentType {
-            ORDER_LIST
+            ORDER_LIST, ORDER_DETAIL
         }
     }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderdetail/OrderDetailFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderdetail/OrderDetailFragment.kt
@@ -1,0 +1,122 @@
+package co.kr.woowahan_banchan.presentation.ui.order.orderdetail
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import co.kr.woowahan_banchan.R
+import co.kr.woowahan_banchan.databinding.FragmentOrderDetailBinding
+import co.kr.woowahan_banchan.databinding.ItemOrderDetailBinding
+import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderItem
+import co.kr.woowahan_banchan.presentation.ui.base.BaseFragment
+import co.kr.woowahan_banchan.presentation.ui.order.OrderActivity
+import co.kr.woowahan_banchan.presentation.ui.productdetail.ProductDetailActivity
+import co.kr.woowahan_banchan.presentation.viewmodel.UiState
+import co.kr.woowahan_banchan.presentation.viewmodel.order.OrderDetailViewModel
+import co.kr.woowahan_banchan.util.ImageLoader
+import co.kr.woowahan_banchan.util.longArgs
+import co.kr.woowahan_banchan.util.shortToast
+import co.kr.woowahan_banchan.util.toPriceFormat
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@AndroidEntryPoint
+class OrderDetailFragment : BaseFragment<FragmentOrderDetailBinding>() {
+    override val layoutRes: Int
+        get() = R.layout.fragment_order_detail
+
+    private val viewModel by viewModels<OrderDetailViewModel>()
+    private val orderId by longArgs()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.fetchOrderItems(orderId)
+        initView()
+        observeData()
+    }
+
+    private fun initView() {
+        (requireActivity() as? OrderActivity)?.setToolbar(OrderActivity.Companion.FragmentType.ORDER_DETAIL)
+    }
+
+    private fun observeData() {
+        viewModel.orderItems
+            .flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach {
+                when (it) {
+                    is UiState.Init -> {
+                        showProgressBar()
+                    }
+                    is UiState.Success -> {
+                        hideProgressBar()
+                        showUi(it.data)
+                    }
+                    is UiState.Error -> {
+                        hideProgressBar()
+                        requireContext().shortToast(it.message)
+                    }
+                }
+            }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun showUi(orderItems: List<OrderItem>) {
+        val menuTotalPrice = orderItems.sumOf { it.price * it.amount }
+        binding.tvMenuAmountValue.text = "총 ${orderItems.size}개"
+        binding.tvMenuPriceValue.text = menuTotalPrice.toPriceFormat() + "원"
+        binding.tvMenuDeliveryFeeValue.text =
+            if (menuTotalPrice >= 40000) "0원"
+            else 2500.toPriceFormat() + "원"
+        binding.tvPriceValue.text =
+            if (menuTotalPrice >= 40000) (menuTotalPrice).toPriceFormat() + "원"
+            else (menuTotalPrice + 2500).toPriceFormat() + "원"
+        if (binding.layoutMenu.childCount == 0) addMenuItemView(orderItems)
+    }
+
+    private fun addMenuItemView(orderItems: List<OrderItem>) {
+        orderItems.forEach { orderItem ->
+            val itemBinding = ItemOrderDetailBinding.inflate(layoutInflater, null, false)
+            ImageLoader.loadImage(orderItem.thumbnailUrl) {
+                if (it != null) {
+                    itemBinding.ivImage.setImageBitmap(it)
+                }
+            }
+            itemBinding.tvTitle.text = orderItem.title
+            itemBinding.tvAmount.text = "${orderItem.amount}개"
+            itemBinding.tvPrice.text = (orderItem.price * orderItem.amount).toPriceFormat() + "원"
+            itemBinding.root.setOnClickListener {
+                startActivity(
+                    ProductDetailActivity.getIntent(
+                        requireContext(),
+                        orderItem.title,
+                        orderItem.hash
+                    )
+                )
+            }
+
+            binding.layoutMenu.addView(itemBinding.root)
+        }
+    }
+
+    private fun showProgressBar() {
+        binding.svOrderDetail.isVisible = false
+        binding.progressBar.isVisible = true
+    }
+
+    private fun hideProgressBar() {
+        binding.svOrderDetail.isVisible = true
+        binding.progressBar.isVisible = false
+    }
+
+    companion object {
+        fun newInstance(orderId: Long): OrderDetailFragment {
+            return OrderDetailFragment().apply {
+                arguments = Bundle().apply {
+                    putLong("orderId", orderId)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/orderlist/OrderListFragment.kt
@@ -3,6 +3,7 @@ package co.kr.woowahan_banchan.presentation.ui.order.orderlist
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -10,11 +11,12 @@ import co.kr.woowahan_banchan.R
 import co.kr.woowahan_banchan.databinding.FragmentOrderListBinding
 import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderHistory
 import co.kr.woowahan_banchan.presentation.adapter.OrderListAdapter
+import co.kr.woowahan_banchan.presentation.decoration.OrderListItemDecoration
 import co.kr.woowahan_banchan.presentation.ui.base.BaseFragment
 import co.kr.woowahan_banchan.presentation.ui.order.OrderActivity
+import co.kr.woowahan_banchan.presentation.ui.order.orderdetail.OrderDetailFragment
 import co.kr.woowahan_banchan.presentation.viewmodel.UiState
 import co.kr.woowahan_banchan.presentation.viewmodel.order.OrderListViewModel
-import co.kr.woowahan_banchan.presentation.decoration.OrderListItemDecoration
 import co.kr.woowahan_banchan.util.dpToPx
 import co.kr.woowahan_banchan.util.shortToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +29,14 @@ class OrderListFragment : BaseFragment<FragmentOrderListBinding>() {
         get() = R.layout.fragment_order_list
 
     private val viewModel by viewModels<OrderListViewModel>()
-    private val orderListAdapter by lazy { OrderListAdapter { requireContext().shortToast("TODO") } }
+    private val orderListAdapter by lazy {
+        OrderListAdapter {
+            parentFragmentManager.commit {
+                replace(R.id.fcv_order, OrderDetailFragment.newInstance(it.orderId))
+                addToBackStack(OrderDetailFragment::class.java.simpleName)
+            }
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -43,7 +52,7 @@ class OrderListFragment : BaseFragment<FragmentOrderListBinding>() {
                 5.dpToPx(),
                 5.dpToPx(),
                 1.dpToPx(),
-                requireContext().resources.getColor(R.color.grayscale_aaaaaa, null)
+                requireContext().resources.getColor(R.color.grayscale_cccccc, null)
             )
         )
         binding.rvOrderList.adapter = orderListAdapter

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
@@ -80,6 +80,7 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
                     is UiState.Error -> {
                         hideProgressBar()
                         shortToast(it.message)
+                        finish()
                     }
                 }
             }.launchIn(lifecycleScope)

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/order/OrderDetailViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/order/OrderDetailViewModel.kt
@@ -1,0 +1,29 @@
+package co.kr.woowahan_banchan.presentation.viewmodel.order
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.viewModelFactory
+import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderItem
+import co.kr.woowahan_banchan.domain.usecase.OrderDetailUseCase
+import co.kr.woowahan_banchan.presentation.viewmodel.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderDetailViewModel @Inject constructor(
+    private val orderDetailUseCase: OrderDetailUseCase
+) : ViewModel() {
+    private val _orderItems = MutableStateFlow<UiState<List<OrderItem>>>(UiState.Init)
+    val orderItems: StateFlow<UiState<List<OrderItem>>> get() = _orderItems
+
+    fun fetchOrderItems(orderId: Long) {
+        viewModelScope.launch {
+            orderDetailUseCase(orderId)
+                .onSuccess { _orderItems.value = UiState.Success(it) }
+                .onFailure { _orderItems.value = UiState.Error(it.message) }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_order_detail.xml
+++ b/app/src/main/res/layout/fragment_order_detail.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grayscale_dcdcdc"
+        tools:context=".presentation.ui.order.orderdetail.OrderDetailFragment">
+
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ScrollView
+            android:id="@+id/sv_order_detail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/tv_title_order_info"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="22dp"
+                    android:textColor="@color/grayscale_000000"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="주문이 접수되었습니다." />
+
+                <LinearLayout
+                    android:id="@+id/layout_delivery_waiting"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="@id/tv_title_order_info"
+                    app:layout_constraintStart_toStartOf="@id/tv_title_order_info"
+                    app:layout_constraintTop_toBottomOf="@id/tv_title_order_info">
+
+                    <TextView
+                        android:id="@+id/tv_delivery_waiting_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="배송까지 남은 시간"
+                        android:textColor="@color/grayscale_828282"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:id="@+id/tv_delivery_waiting_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:textColor="@color/grayscale_000000"
+                        android:textSize="14sp"
+                        tools:text="20분" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/layout_menu_amount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="@id/tv_title_order_info"
+                    app:layout_constraintStart_toStartOf="@id/tv_title_order_info"
+                    app:layout_constraintTop_toBottomOf="@id/layout_delivery_waiting">
+
+                    <TextView
+                        android:id="@+id/tv_menu_amount_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="주문한 상품"
+                        android:textColor="@color/grayscale_828282"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:id="@+id/tv_menu_amount_value"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:textColor="@color/grayscale_000000"
+                        android:textSize="14sp"
+                        tools:text="총 2개" />
+
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="24dp"
+                    android:background="@color/grayscale_cccccc"
+                    app:layout_constraintTop_toBottomOf="@id/layout_menu_amount" />
+
+                <LinearLayout
+                    android:id="@+id/layout_menu"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="25dp"
+                    android:background="@color/grayscale_ffffff"
+                    android:orientation="vertical"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="8dp"
+                    app:layout_constraintTop_toBottomOf="@id/layout_menu_amount" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="@color/grayscale_cccccc"
+                    app:layout_constraintTop_toBottomOf="@id/layout_menu" />
+
+                <TextView
+                    android:id="@+id/tv_menu_price_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="120dp"
+                    android:text="상품 주문 금액"
+                    android:textColor="@color/grayscale_828282"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_menu_price_value"
+                    app:layout_constraintEnd_toStartOf="@id/tv_menu_price_value"
+                    app:layout_constraintTop_toTopOf="@id/tv_menu_price_value" />
+
+                <TextView
+                    android:id="@+id/tv_menu_price_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="28dp"
+                    android:layout_marginEnd="16dp"
+                    android:textColor="@color/grayscale_828282"
+                    android:textSize="14sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/layout_menu"
+                    tools:text="18,640원" />
+
+                <TextView
+                    android:id="@+id/tv_menu_delivery_fee_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="120dp"
+                    android:text="배송료"
+                    android:textColor="@color/grayscale_828282"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_menu_delivery_fee_value"
+                    app:layout_constraintStart_toStartOf="@id/tv_menu_price_label"
+                    app:layout_constraintTop_toTopOf="@id/tv_menu_delivery_fee_value" />
+
+                <TextView
+                    android:id="@+id/tv_menu_delivery_fee_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:layout_marginEnd="16dp"
+                    android:textColor="@color/grayscale_828282"
+                    android:textSize="14sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_price_value"
+                    tools:text="2,500원" />
+
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@color/grayscale_cccccc"
+                    app:layout_constraintEnd_toEndOf="@id/tv_menu_price_value"
+                    app:layout_constraintStart_toStartOf="@id/tv_menu_price_label"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_delivery_fee_value" />
+
+                <TextView
+                    android:id="@+id/tv_price_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="120dp"
+                    android:text="총 결제 금액"
+                    android:textColor="@color/grayscale_000000"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_price_value"
+                    app:layout_constraintStart_toStartOf="@id/tv_menu_price_label"
+                    app:layout_constraintTop_toTopOf="@id/tv_price_value" />
+
+                <TextView
+                    android:id="@+id/tv_price_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="21dp"
+                    android:layout_marginEnd="16dp"
+                    android:layout_marginBottom="40dp"
+                    android:textColor="@color/grayscale_000000"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_menu_delivery_fee_value"
+                    tools:text="21,140원" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </ScrollView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_order_detail.xml
+++ b/app/src/main/res/layout/item_order_detail.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingVertical="8dp">
+
+    <ImageView
+        android:id="@+id/iv_image"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@mipmap/ic_launcher" />
+
+    <LinearLayout
+        android:id="@+id/layout_info"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iv_image"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/grayscale_000000"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/iv_image"
+            app:layout_constraintTop_toTopOf="@id/iv_image"
+            tools:text="새콤달콤 오징어무침" />
+
+        <TextView
+            android:id="@+id/tv_amount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/grayscale_000000"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            tools:text="1개" />
+
+        <TextView
+            android:id="@+id/tv_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/grayscale_000000"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_amount"
+            tools:text="6,000원" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,7 +17,7 @@
     <color name="grayscale_ffffff">#FFFFFF</color>
     <color name="grayscale_f5f5f7">#F5F5F7</color>
     <color name="grayscale_dcdcdc">#DCDCDC</color>
-    <color name="grayscale_aaaaaa">#AAAAAA</color>
+    <color name="grayscale_cccccc">#CCCCCC</color>
 
     <color name="primary_f46700">#F46700</color>
     <color name="primary_f9ba70">#F9BA70</color>


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #58 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 주문 내역 상세 화면 기초 기능 구현

### Description
![image](https://user-images.githubusercontent.com/81508084/184488880-db5b9934-c9b5-42d4-afb9-ba73a8fdb8fc.png)![image](https://user-images.githubusercontent.com/81508084/184490759-c4fa52ce-224b-4ad5-a66f-0b62078445d3.png)

OrderDetail에는 이런 화면이 있는데, 쿠팡과 같은 단순 물품이 아닌 `식품` 주문 앱이라는 것을 감안했을 때, 주문 한 번에 과연 수십, 수백 개의 메뉴를 주문할까? 하는 생각이 들었어.
어쩌면 개발자의 오만한 판단일 수 있지만, 한 번에 20개가 넘는 반찬을 주문할 사람이 있을까?
1달치 반찬을 미리 배송시키는 사람이 있을까?

나는 없을 것 같다고 판단했고, 그래서 `RecyclerView`를 사용하지 않고 그냥 Item 레이아웃 xml 파일을 만들었네.
이를 inflate시켜 forEach를 통해 반복적으로 `LinearLayout에 addView` 하는 것이 더 효율적이라는 판단을 했어.
**ViewHolder가 재사용이 될 가능성이 적은데** RecyclerView를 사용하는 것이 과연 효과가 있을까?
RecyclerView가 `NestedScrollView` 안에 배치되어 있으면 ViewHolder를 재사용하는 것이 아니라, 다 만들어놓고 그저 스크롤되게 하기만 하는 것이라는 것은 금요일 데모 때 우리끼리 얘기한 것 같아.
그래서 주문 내역이 한 10개쯤 되어서 스크롤 될 것까지 생각했을 때, `NestedScrollView`도 사용하지 않고, RecyclerView를 쓰려면 ViewType을 나눠야 하는데 과연 꼭 그래야할까? 라는 생각이 들었어.

이런 근거로 그냥 동적으로 뷰 생성해서 레이아웃에 배치하는 코드로 작성했다네 !

혹시라도 뭔가 의견이 다르다면 꼭 의견 남겨줘 !

### What's Next ?
꼭 알려야 할 것 같은 일인데, 현재 Dao는 Order 테이블의 모든 아이템을 가져오는 메서드는 있지만, 특정 id를 가진 아이템만을 가져오는 메서드는 없다네.
특정 id를 가진 아이템만 가져오는 메서드가 왜 필요하냐면, 주문시간, 이것을 기준으로 배송 중인지, 배송 완료인지를 처리해야 하는데 이건 Order 테이블에만 있기 때문이야.
그래서 다음 PR에는 아마 이 부분이 추가될 것 같네, Skipancho.