### PR TITLE
[FEATURE] 장바구니 아이콘에 Badge 추가

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
@@ -3,6 +3,8 @@ package co.kr.woowahan_banchan.data.repository
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.model.local.CartDto
 import co.kr.woowahan_banchan.domain.repository.CartRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import java.util.*
 import javax.inject.Inject
 
@@ -14,5 +16,10 @@ class CartRepositoryImpl @Inject constructor(
         cartDataSource.insertOrUpdateItems(
             listOf(CartDto(hash, amount + originalAmount, true, Date().time, name))
         )
+    }
+
+    override fun getCartItemCount(): Flow<Int> {
+        return cartDataSource.getItems()
+            .map { it.size }
     }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/repository/CartRepository.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/repository/CartRepository.kt
@@ -1,5 +1,8 @@
 package co.kr.woowahan_banchan.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
 interface CartRepository {
     suspend fun addToCart(hash: String, amount: Int, name: String)
+    fun getCartItemCount(): Flow<Int>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/GetCartItemCountUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/GetCartItemCountUseCase.kt
@@ -1,0 +1,11 @@
+package co.kr.woowahan_banchan.domain.usecase
+
+import co.kr.woowahan_banchan.domain.repository.CartRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCartItemCountUseCase @Inject constructor(
+    private val cartRepository: CartRepository
+) {
+    operator fun invoke(): Flow<Int> = cartRepository.getCartItemCount()
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
@@ -3,10 +3,16 @@ package co.kr.woowahan_banchan.presentation.ui.main
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.viewModels
 import co.kr.woowahan_banchan.R
 import co.kr.woowahan_banchan.databinding.ActivityMainBinding
 import co.kr.woowahan_banchan.presentation.adapter.ViewPagerAdapter
 import co.kr.woowahan_banchan.presentation.ui.base.BaseActivity
+import co.kr.woowahan_banchan.presentation.viewmodel.MainViewModel
+import co.kr.woowahan_banchan.util.dpToPx
+import com.google.android.material.badge.BadgeDrawable
+import com.google.android.material.badge.BadgeUtils
+import com.google.android.material.badge.ExperimentalBadgeUtils
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -15,6 +21,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
     override val layoutRes: Int
         get() = R.layout.activity_main
 
+    private val viewModel by viewModels<MainViewModel>()
+
     private val tabTitleArray = arrayOf(
         "기획전",
         "든든한 메인요리",
@@ -22,11 +30,22 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         "정갈한 밑반찬"
     )
 
+    private val badge by lazy {
+        BadgeDrawable.create(this).also { bd ->
+            bd.backgroundColor = resources.getColor(R.color.grayscale_000000,theme)
+            bd.horizontalOffset = 5.dpToPx()
+            bd.verticalOffset = 5.dpToPx()
+            bd.maxCharacterCount = 3
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         initToolbar()
         initView()
+        observeData()
+
+        viewModel.getCartItemCount()
     }
 
     private fun initToolbar(){
@@ -43,8 +62,17 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         }
     }
 
+    private fun observeData(){
+        viewModel.cartCount.observe(this){
+            badge.number = it
+            badge.isVisible = it > 0
+        }
+    }
+
+    @ExperimentalBadgeUtils
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.menu_app_bar,menu)
+        BadgeUtils.attachBadgeDrawable(badge,binding.tbToolbar,R.id.action_cart)
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import co.kr.woowahan_banchan.R
 import co.kr.woowahan_banchan.databinding.ActivityMainBinding
 import co.kr.woowahan_banchan.presentation.adapter.ViewPagerAdapter
@@ -15,6 +17,8 @@ import com.google.android.material.badge.BadgeUtils
 import com.google.android.material.badge.ExperimentalBadgeUtils
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>() {
@@ -32,7 +36,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
 
     private val badge by lazy {
         BadgeDrawable.create(this).also { bd ->
-            bd.backgroundColor = resources.getColor(R.color.grayscale_000000,theme)
+            bd.backgroundColor = resources.getColor(R.color.grayscale_000000, theme)
             bd.horizontalOffset = 5.dpToPx()
             bd.verticalOffset = 5.dpToPx()
             bd.maxCharacterCount = 3
@@ -48,36 +52,37 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         viewModel.getCartItemCount()
     }
 
-    private fun initToolbar(){
+    private fun initToolbar() {
         setSupportActionBar(binding.tbToolbar)
     }
 
-    private fun initView(){
-        with(binding){
+    private fun initView() {
+        with(binding) {
             vpFragmentPager.adapter = ViewPagerAdapter(supportFragmentManager, lifecycle)
 
-            TabLayoutMediator(layoutFragmentTab,vpFragmentPager){ tab, position ->
+            TabLayoutMediator(layoutFragmentTab, vpFragmentPager) { tab, position ->
                 tab.text = tabTitleArray[position]
             }.attach()
         }
     }
 
-    private fun observeData(){
-        viewModel.cartCount.observe(this){
-            badge.number = it
-            badge.isVisible = it > 0
-        }
+    private fun observeData() {
+        viewModel.cartCount.flowWithLifecycle(this.lifecycle)
+            .onEach {
+                badge.number = it
+                badge.isVisible = it > 0
+            }.launchIn(lifecycleScope)
     }
 
     @ExperimentalBadgeUtils
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.menu_app_bar,menu)
-        BadgeUtils.attachBadgeDrawable(badge,binding.tbToolbar,R.id.action_cart)
+        menuInflater.inflate(R.menu.menu_app_bar, menu)
+        BadgeUtils.attachBadgeDrawable(badge, binding.tbToolbar, R.id.action_cart)
         return super.onCreateOptionsMenu(menu)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when(item.itemId){
+        when (item.itemId) {
             R.id.action_cart -> {
                 //move to cart
             }

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/MainViewModel.kt
@@ -1,12 +1,28 @@
 package co.kr.woowahan_banchan.presentation.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.kr.woowahan_banchan.domain.usecase.GetCartItemCountUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor() : ViewModel() {
+class MainViewModel @Inject constructor(
+    private val getCartItemCountUseCase: GetCartItemCountUseCase
+) : ViewModel() {
 
+    private val _cartCount = MutableLiveData(0)
+    val cartCount: LiveData<Int> get() = _cartCount
+
+    fun getCartItemCount() = viewModelScope.launch {
+        getCartItemCountUseCase()
+            .catch { _cartCount.value = 0 }
+            .collect {
+                _cartCount.value = it
+            }
+    }
 }
-
-

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/MainViewModel.kt
@@ -1,11 +1,11 @@
 package co.kr.woowahan_banchan.presentation.viewmodel
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.kr.woowahan_banchan.domain.usecase.GetCartItemCountUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,8 +15,8 @@ class MainViewModel @Inject constructor(
     private val getCartItemCountUseCase: GetCartItemCountUseCase
 ) : ViewModel() {
 
-    private val _cartCount = MutableLiveData(0)
-    val cartCount: LiveData<Int> get() = _cartCount
+    private val _cartCount = MutableStateFlow(0)
+    val cartCount: StateFlow<Int> get() = _cartCount
 
     fun getCartItemCount() = viewModelScope.launch {
         getCartItemCountUseCase()


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #69 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] CartRepository에 장바구니 목록 개수를 가져오는 함수 추가
- [x] 장바구니 목록 개수를 가져오는 UseCase 구현
- [x] 장바구니 아이콘 뱃지 구현

close #69

To. Iceman (@hansh0101)

음.. 아이콘의 뱃지는 우선 BadgeDrawble과 BadgeUtils을 이용해서 구현을 했다네... 그와중@ExperimentalBadgeUtils 어노테이션이 필요하다는 경고를 보고 해당 API를 확인해보았지...
다음은 BadgeUtils에 대한 공식 문서의 첫 설명이네
>Utility class for [BadgeDrawable](https://developer.android.com/reference/com/google/android/material/badge/BadgeDrawable).
>
>Warning: This class is experimental and the APIs are subject to change.

아뿔싸... 언제 바뀌어도 이상하지 않은 실험적인 클래스라는군...
다른 방법으로 구현하는 것을 고려해야 할 듯 싶어

From. Skipancho (@Skipancho)