### PR TITLE
[REFACTOR] #73 - 텍스트 위아래 정렬 맞추기

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
@@ -10,6 +10,7 @@ import co.kr.woowahan_banchan.R
 import co.kr.woowahan_banchan.databinding.ActivityMainBinding
 import co.kr.woowahan_banchan.presentation.adapter.ViewPagerAdapter
 import co.kr.woowahan_banchan.presentation.ui.base.BaseActivity
+import co.kr.woowahan_banchan.presentation.ui.order.OrderActivity
 import co.kr.woowahan_banchan.presentation.viewmodel.MainViewModel
 import co.kr.woowahan_banchan.util.dpToPx
 import com.google.android.material.badge.BadgeDrawable
@@ -87,7 +88,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
                 //move to cart
             }
             R.id.action_history -> {
-                //move to history
+                startActivity(OrderActivity.getIntent(this))
             }
         }
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/OrderActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/order/OrderActivity.kt
@@ -1,5 +1,7 @@
 package co.kr.woowahan_banchan.presentation.ui.order
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.add
 import androidx.fragment.app.commit
@@ -39,8 +41,7 @@ class OrderActivity : BaseActivity<ActivityOrderBinding>() {
     }
 
     companion object {
-        enum class FragmentType {
-            ORDER_LIST, ORDER_DETAIL
-        }
+        fun getIntent(context: Context): Intent =
+            Intent(context, OrderActivity::class.java)
     }
 }

--- a/app/src/main/res/layout/item_order_list.xml
+++ b/app/src/main/res/layout/item_order_list.xml
@@ -17,43 +17,54 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@mipmap/ic_launcher" />
 
-        <TextView
-            android:id="@+id/tv_title"
+        <LinearLayout
+            android:id="@+id/layout_info"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:ellipsize="end"
-            android:lines="1"
-            android:textColor="@color/grayscale_000000"
-            android:textSize="14sp"
-            android:textStyle="bold"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="@id/iv_thumbnail"
             app:layout_constraintEnd_toStartOf="@id/iv_arrow"
             app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
-            app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
-            tools:text="새콤달콤 오징어무침 외 1개" />
+            app:layout_constraintTop_toTopOf="@id/iv_thumbnail">
 
-        <TextView
-            android:id="@+id/tv_price"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textColor="@color/grayscale_000000"
-            android:textSize="14sp"
-            app:layout_constraintStart_toStartOf="@id/tv_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_title"
-            tools:text="21,140원" />
+            <TextView
+                android:id="@+id/tv_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:lines="1"
+                android:textColor="@color/grayscale_000000"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toStartOf="@id/iv_arrow"
+                app:layout_constraintStart_toEndOf="@id/iv_thumbnail"
+                app:layout_constraintTop_toTopOf="@id/iv_thumbnail"
+                tools:text="새콤달콤 오징어무침 외 1개" />
 
-        <TextView
-            android:id="@+id/tv_delivery_info"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textSize="14sp"
-            android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="@id/tv_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_price"
-            tools:text="배송 준비 중" />
+            <TextView
+                android:id="@+id/tv_price"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="@color/grayscale_000000"
+                android:textSize="14sp"
+                app:layout_constraintStart_toStartOf="@id/tv_title"
+                app:layout_constraintTop_toBottomOf="@id/tv_title"
+                tools:text="21,140원" />
+
+            <TextView
+                android:id="@+id/tv_delivery_info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="@id/tv_title"
+                app:layout_constraintTop_toBottomOf="@id/tv_price"
+                tools:text="배송 준비 중" />
+
+        </LinearLayout>
 
         <ImageView
             android:id="@+id/iv_arrow"


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #73 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 텍스트 위아래 정렬 맞추기
- [x] MainActivity에서 프로필 아이콘 누를 때 주문 내역 화면으로 이동

큰 건 없고, 주문내역 목록에서 텍스트가 위아래로 margin이 다른 것 같아 찝찝하여 Layout 하나를 감싸버렸다네.

close #73 