### PR TITLE
[FEATURE] ProductDetailActivity에서 조회한 메뉴를 History 테이블에 저장

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSource.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface HistoryDataSource {
     fun getItems(): Flow<List<HistoryDto>>
     fun getPreviewItems(): Flow<List<HistoryDto>>
-    suspend fun insertItem(item: HistoryDto): Result<Unit>
+    suspend fun insertItem(hash: String, name: String): Result<Unit>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
@@ -8,12 +8,13 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.util.*
 import javax.inject.Inject
 
 class HistoryDataSourceImpl @Inject constructor(
     private val historyDao: HistoryDao,
     private val coroutineDispatcher: CoroutineDispatcher
-): HistoryDataSource {
+) : HistoryDataSource {
     override fun getItems(): Flow<List<HistoryDto>> =
         historyDao.getItems()
             .catch { exception ->
@@ -28,10 +29,12 @@ class HistoryDataSourceImpl @Inject constructor(
                 emit(listOf())
             }.flowOn(coroutineDispatcher)
 
-    override suspend fun insertItem(item: HistoryDto) =
+    override suspend fun insertItem(hash: String, name: String) =
         withContext(coroutineDispatcher) {
             runCatching {
-                historyDao.insertItem(item)
+                historyDao.insertItem(
+                    HistoryDto(hash, Date().time, name)
+                )
             }
         }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
@@ -3,6 +3,7 @@ package co.kr.woowahan_banchan.data.repository
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.data.model.local.HistoryDto
 import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import co.kr.woowahan_banchan.domain.repository.HistoryRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -18,6 +19,10 @@ class HistoryRepositoryImpl @Inject constructor(
     private val detailDataSource: DetailDataSource,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : HistoryRepository {
+    override suspend fun addToHistory(hash: String, name: String) {
+        historyDataSource.insertItem(hash, name)
+    }
+
     override fun getHistories(previewMode: Boolean): Flow<List<HistoryItem>> {
         return combine(
             if (previewMode) historyDataSource.getPreviewItems() else historyDataSource.getItems(),

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
@@ -1,6 +1,5 @@
 package co.kr.woowahan_banchan.domain.repository
 
-import androidx.room.PrimaryKey
 import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/repository/HistoryRepository.kt
@@ -1,8 +1,10 @@
 package co.kr.woowahan_banchan.domain.repository
 
+import androidx.room.PrimaryKey
 import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import kotlinx.coroutines.flow.Flow
 
 interface HistoryRepository {
+    suspend fun addToHistory(hash: String, name: String)
     fun getHistories(previewMode: Boolean): Flow<List<HistoryItem>>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/HistoryAddUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/HistoryAddUseCase.kt
@@ -1,0 +1,13 @@
+package co.kr.woowahan_banchan.domain.usecase
+
+import co.kr.woowahan_banchan.domain.repository.HistoryRepository
+import javax.inject.Inject
+
+class HistoryAddUseCase @Inject constructor(
+    private val historyRepository: HistoryRepository
+) {
+    suspend operator fun invoke(hash: String, name: String): Result<Unit> =
+        runCatching {
+            historyRepository.addToHistory(hash, name)
+        }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
@@ -42,6 +42,7 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
         hash = intent.getStringExtra("HASH") ?: error("Hash not delivered")
         title = intent.getStringExtra("TITLE") ?: error("Title not delivered")
         viewModel.fetchUiState(hash)
+        viewModel.addToHistory(hash, title)
         initView()
         initOnClickListener()
         observeData()

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.kr.woowahan_banchan.domain.entity.detail.DishInfo
 import co.kr.woowahan_banchan.domain.usecase.CartAddUseCase
+import co.kr.woowahan_banchan.domain.usecase.HistoryAddUseCase
 import co.kr.woowahan_banchan.domain.usecase.ProductDetailUseCase
 import co.kr.woowahan_banchan.presentation.viewmodel.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,12 +13,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class ProductDetailViewModel @Inject constructor(
     private val productDetailUseCase: ProductDetailUseCase,
-    private val cartAddUseCase: CartAddUseCase
+    private val cartAddUseCase: CartAddUseCase,
+    private val historyAddUseCase: HistoryAddUseCase
 ) : ViewModel() {
     private val _dishInfo = MutableStateFlow<UiState<DishInfo>>(UiState.Init)
     val dishInfo: StateFlow<UiState<DishInfo>> get() = _dishInfo
@@ -31,6 +34,13 @@ class ProductDetailViewModel @Inject constructor(
             productDetailUseCase(hash)
                 .onSuccess { _dishInfo.value = UiState.Success(it) }
                 .onFailure { _dishInfo.value = UiState.Error(it.message) }
+        }
+    }
+
+    fun addToHistory(hash: String, name: String) {
+        viewModelScope.launch {
+            historyAddUseCase(hash, name)
+                .onFailure { Timber.e(it) }
         }
     }
 


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #75 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] ProductDetailActivity에서 조회한 반찬을 History 테이블에 저장
- [x] 현재 시간을 View가 하위 모듈에게 전달하는 것이 아닌, DataSource에서 계산해 바로 Dao에 전달하도록 코드 수정

Skipancho, 일전에 이야기한 내용이 들어있네.
과연 View가 현재 시간을 꼭 ViewModel에 전달하는게 의미가 있을까? 그냥 바로 DataSource에서 시간을 계산해서 Dao에 넘겨주면 안 될까? 에 대해 말했던 내용이 기억나나?
이번 PR은 해당 내용이 담겨있네.
그럼, 이만!