### PR TITLE
[FEATURE] RecentlyViewedFragment RecyclerView Item Click Event 처리

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/domain/entity/history/HistoryItem.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/entity/history/HistoryItem.kt
@@ -1,5 +1,8 @@
 package co.kr.woowahan_banchan.domain.entity.history
 
+import co.kr.woowahan_banchan.domain.entity.dish.Dish
+import kotlin.math.roundToInt
+
 data class HistoryItem(
     val detailHash: String,
     val imageUrl: String,
@@ -8,4 +11,24 @@ data class HistoryItem(
     val sPrice: Int,
     val time: Long,
     val isAdded: Boolean
-)
+) {
+    fun toDish(): Dish {
+        return Dish(
+            detailHash = detailHash,
+            imageUrl = imageUrl,
+            alt = this.title,
+            deliveryType = listOf(),
+            title = this.title,
+            description = "",
+            discount = if (nPrice == null) {
+                0
+            } else {
+                ((nPrice - sPrice).toDouble() / nPrice.toDouble()).roundToInt()
+            },
+            nPrice = this.nPrice,
+            sPrice = this.sPrice,
+            badge = null,
+            isAdded = this.isAdded
+        )
+    }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/adapter/RecentlyViewedAdapter.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/adapter/RecentlyViewedAdapter.kt
@@ -14,9 +14,16 @@ import co.kr.woowahan_banchan.util.calculateDiff
 import co.kr.woowahan_banchan.util.toPriceFormat
 import java.util.*
 
-class RecentlyViewedAdapter :
+class RecentlyViewedAdapter(
+    private val itemClick: (HistoryItem) -> Unit,
+    private val cartClick: (HistoryItem) -> Unit
+) :
     ListAdapter<HistoryItem, RecentlyViewedAdapter.RecentlyViewedViewHolder>(diffCallback) {
-    class RecentlyViewedViewHolder(private val binding: ItemRecentlyViewedBinding) :
+    class RecentlyViewedViewHolder(
+        private val binding: ItemRecentlyViewedBinding,
+        private val itemClick: (HistoryItem) -> Unit,
+        private val cartClick: (HistoryItem) -> Unit
+    ) :
         RecyclerView.ViewHolder(binding.root) {
         fun onBind(historyItem: HistoryItem) {
             with(historyItem) {
@@ -42,22 +49,28 @@ class RecentlyViewedAdapter :
                 }
                 binding.tvTime.text = Date().time.calculateDiff(this.time)
             }
+            binding.root.setOnClickListener { itemClick(historyItem) }
+            binding.ibAddBtn.setOnClickListener { cartClick(historyItem) }
         }
 
         companion object {
-            fun create(parent: ViewGroup): RecentlyViewedViewHolder {
+            fun create(
+                parent: ViewGroup,
+                itemClick: (HistoryItem) -> Unit,
+                cartClick: (HistoryItem) -> Unit
+            ): RecentlyViewedViewHolder {
                 val binding = ItemRecentlyViewedBinding.inflate(
                     LayoutInflater.from(parent.context),
                     parent,
                     false
                 )
-                return RecentlyViewedViewHolder(binding)
+                return RecentlyViewedViewHolder(binding, itemClick, cartClick)
             }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecentlyViewedViewHolder =
-        RecentlyViewedViewHolder.create(parent)
+        RecentlyViewedViewHolder.create(parent, itemClick, cartClick)
 
     override fun onBindViewHolder(holder: RecentlyViewedViewHolder, position: Int) =
         holder.onBind(currentList[position])

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/recentlyviewed/RecentlyViewedFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/recentlyviewed/RecentlyViewedFragment.kt
@@ -11,6 +11,8 @@ import co.kr.woowahan_banchan.databinding.FragmentRecentlyViewedBinding
 import co.kr.woowahan_banchan.presentation.adapter.RecentlyViewedAdapter
 import co.kr.woowahan_banchan.presentation.decoration.GridItemDecoration
 import co.kr.woowahan_banchan.presentation.ui.base.BaseFragment
+import co.kr.woowahan_banchan.presentation.ui.productdetail.ProductDetailActivity
+import co.kr.woowahan_banchan.presentation.ui.widget.CartAddBottomSheet
 import co.kr.woowahan_banchan.presentation.viewmodel.UiState
 import co.kr.woowahan_banchan.presentation.viewmodel.cart.RecentlyViewedViewModel
 import co.kr.woowahan_banchan.util.dpToPx
@@ -25,7 +27,19 @@ class RecentlyViewedFragment : BaseFragment<FragmentRecentlyViewedBinding>() {
         get() = R.layout.fragment_recently_viewed
 
     private val viewModel by viewModels<RecentlyViewedViewModel>()
-    private val recentlyViewedAdapter by lazy { RecentlyViewedAdapter() }
+    private val recentlyViewedAdapter by lazy {
+        RecentlyViewedAdapter({
+            startActivity(
+                ProductDetailActivity.getIntent(
+                    requireContext(),
+                    it.title,
+                    it.detailHash
+                )
+            )
+        }, {
+            CartAddBottomSheet.newInstance(it.toDish()).show(parentFragmentManager, null)
+        })
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -37,7 +51,13 @@ class RecentlyViewedFragment : BaseFragment<FragmentRecentlyViewedBinding>() {
     private fun initView() {
         initToolbar()
         binding.rvRecentlyViewed.adapter = recentlyViewedAdapter
-        binding.rvRecentlyViewed.addItemDecoration(GridItemDecoration(16.dpToPx(), 32.dpToPx(), 8.dpToPx()))
+        binding.rvRecentlyViewed.addItemDecoration(
+            GridItemDecoration(
+                16.dpToPx(),
+                32.dpToPx(),
+                8.dpToPx()
+            )
+        )
     }
 
     private fun initData() {
@@ -48,7 +68,7 @@ class RecentlyViewedFragment : BaseFragment<FragmentRecentlyViewedBinding>() {
         viewModel.historyItems
             .flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
-                when(it) {
+                when (it) {
                     is UiState.Init -> {
                         showProgressBar()
                     }


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #78 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] item 클릭 시 ProductDetailActivity로 전환 구현
- [x] item의 ImageButton 클릭 시 CartAddBottomSheetDialogFragment 표시 구현
- [x] HistoryItem을 Dish 타입으로 변환해주는 Mapper 메서드 구현

### Must Think About

한 번 생각을 해보면 좋을 것 같은 주제가 있네... Skipancho.
CartAddBottomSheetd에서는 data 타입을 `Dish`로 하고 있더군.
과연 Dish라는 타입이 `일반적`인가? 라는 부분에 의문이 생기긴 했어.
BottomSheetDialog에서 필요한 데이터는 내가 분석했을 때, 이렇더라고.

> 화면에 보이는 것: ImageUrl, title(name), sPrice, nPrice
> 화면에 보이지 않는 것: hash

나머지 것들은 수량과, 수량에 따른 가격인데 이는 BottomSheetDialog 자체에서 처리할 수 있을 것 같았네.
실제로 UseCase에 전달하는 값은 `hash`, `amount`, `title` 이 3가지이고 말이야.
그렇다면 과연 BottomSheetDialog에 넘겨줄 데이터의 타입을 `Dish`로 하는게 좋을까? 라는 생각이 들었네.

내 제안은, BottomSheetDialog가 필요로 하는 데이터의 타입만을 쏙 뽑아내서 하나의 새로운 data class를 정의함이 어떻겠는가?
뭔가 추후 재사용과 확장에 더 용이할 것 같다는 생각을 했네.
일단은 내 `HistoryItem`을 `Dish`로 Mapping해주는 함수를 구현함으로 동작은 하도록 만들었네.

자네의 코딩 친구, Iceman이.

close #78 