### PR TITLE
[FEATURE] ErrorClassifer 인터페이스 및 구현체 구현

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/classifier/ErrorClassifierImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/classifier/ErrorClassifierImpl.kt
@@ -1,0 +1,27 @@
+package co.kr.woowahan_banchan.data.classifier
+
+import co.kr.woowahan_banchan.domain.classifier.ErrorClassifier
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import retrofit2.HttpException
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.HttpRetryException
+import java.net.HttpURLConnection
+import java.net.UnknownHostException
+import java.nio.channels.InterruptedByTimeoutException
+
+class ErrorClassifierImpl : ErrorClassifier {
+    override fun classifyError(throwable: Throwable): ErrorEntity =
+        when (throwable) {
+            is HttpRetryException, is InterruptedIOException, is InterruptedByTimeoutException -> ErrorEntity.RetryableError
+            is UnknownHostException -> ErrorEntity.ConditionalError
+            is IOException -> ErrorEntity.UnknownError
+            is HttpException -> {
+                when (throwable.code()) {
+                    HttpURLConnection.HTTP_CLIENT_TIMEOUT, HttpURLConnection.HTTP_GATEWAY_TIMEOUT -> ErrorEntity.RetryableError
+                    else -> ErrorEntity.UnknownError
+                }
+            }
+            else -> ErrorEntity.UnknownError
+        }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/classifier/ErrorClassifier.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/classifier/ErrorClassifier.kt
@@ -1,0 +1,7 @@
+package co.kr.woowahan_banchan.domain.classifier
+
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+
+interface ErrorClassifier {
+    fun classifyError(throwable: Throwable): ErrorEntity
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/entity/error/ErrorEntity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/entity/error/ErrorEntity.kt
@@ -1,0 +1,13 @@
+package co.kr.woowahan_banchan.domain.entity.error
+
+/*
+* ErrorEntity Type
+* RetryableError - Network 통신과 관련하여 단순히 재시도해도 성공할 가능성이 있는 Error
+* ConditionalError - 특정 조건이 충족되지 않아 발생하는 Error. 즉, 해당 조건을 충족하면 해결될 Error
+* UnknownError - 위 2가지와 관련되지 않은 Error
+*/
+sealed class ErrorEntity {
+    object RetryableError: ErrorEntity()
+    object ConditionalError: ErrorEntity()
+    object UnknownError: ErrorEntity()
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #105 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] ErrorClassifier 인터페이스 생성
- [x] ErrorClassifier 구현체 생성

### 참고사항
- **ErrorEntity.RetryableError**: HttpRetryException, InterruptedIOException, InterruptedByTimeoutException, HttpException 중 timeout 관련
- **ErrorEntity.ConditionalError**: UnknownHostException
- **ErrorEntity.UnknownError**: IOException, else

아래는 공식문서 및 내부 코드를 참고한 내용일세.
재시도해서 성공할 것 같은 Exception들은 내가 판단하기에 이런 공통점이 있어.

1. Retry를 해야하는데 하지 못한 경우
2. Interrupt된 경우
3. TimeOut

또, ConditionalError로 판단한 UnknownHostException의 경우는 내가 종종 네트워크에 연결되지 않은 채로 빌드하면 생기는 Exception이더군. 추가로 더 찾아보니, 폐쇄망에 요청을 보내야 하는데 현재 연결된 네트워크는 해당 폐쇄망이 아닌 경우에 뜬다고도 하더군.

이외의 IOException이나 기타 Exception은 UnknownError로 처리했네.

<table style = "table-layout: auto; width: 100%; table-layout: fixed;">
  <colgroup>
    <col style="width:50%"/>
    <col style="width:50%"/>
  </colgroup>
  <tr>
    <td align="center">
      Exception
    </td>
    <td align="center">
      설명
    </td>
  </tr>
  <tr>
    <th>HttpRetryException</th>
    <td>Thrown to indicate that a HTTP request needs to be retried but cannot be retried automatically, due to streaming mode being enabled. </td>
  </tr>
  <tr>
    <th>InterruptedIOException</th>
    <td>Signals that an I/O operation has been interrupted.  </td>
  </tr>
  <tr>
    <th>InterruptedByTimeoutException</th>
    <td>Checked exception received by a thread when a timeout elapses before an asynchronous operation completes.  </td>
  </tr>
  <tr>    
    <th>HttpException 중 timeout 관련</th>
    <td>HTTP Status-Code 408: Request Time-Out.<br>HTTP Status-Code 504: Gateway Timeout. </td>
  </tr>
  <tr>
    <th>UnknownHostException</th>
    <td>Thrown to indicate that the IP address of a host could not be determined.  </td>
  </tr>
  <tr>
    <th>IOException</th>
    <td> </td>
  </tr>
</table>