### PR TITLE
[FEATURE] sealed class CustomResult 추가

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/classifier/ErrorClassifierImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/classifier/ErrorClassifierImpl.kt
@@ -1,0 +1,27 @@
+package co.kr.woowahan_banchan.data.classifier
+
+import co.kr.woowahan_banchan.domain.classifier.ErrorClassifier
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import retrofit2.HttpException
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.HttpRetryException
+import java.net.HttpURLConnection
+import java.net.UnknownHostException
+import java.nio.channels.InterruptedByTimeoutException
+
+class ErrorClassifierImpl : ErrorClassifier {
+    override fun classifyError(throwable: Throwable): ErrorEntity =
+        when (throwable) {
+            is HttpRetryException, is InterruptedIOException, is InterruptedByTimeoutException -> ErrorEntity.RetryableError
+            is UnknownHostException -> ErrorEntity.ConditionalError
+            is IOException -> ErrorEntity.UnknownError
+            is HttpException -> {
+                when (throwable.code()) {
+                    HttpURLConnection.HTTP_CLIENT_TIMEOUT, HttpURLConnection.HTTP_GATEWAY_TIMEOUT -> ErrorEntity.RetryableError
+                    else -> ErrorEntity.UnknownError
+                }
+            }
+            else -> ErrorEntity.UnknownError
+        }
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/classifier/ErrorClassifier.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/classifier/ErrorClassifier.kt
@@ -1,0 +1,7 @@
+package co.kr.woowahan_banchan.domain.classifier
+
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+
+interface ErrorClassifier {
+    fun classifyError(throwable: Throwable): ErrorEntity
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/entity/error/ErrorEntity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/entity/error/ErrorEntity.kt
@@ -1,0 +1,13 @@
+package co.kr.woowahan_banchan.domain.entity.error
+
+/*
+* ErrorEntity Type
+* RetryableError - Network 통신과 관련하여 단순히 재시도해도 성공할 가능성이 있는 Error
+* ConditionalError - 특정 조건이 충족되지 않아 발생하는 Error. 즉, 해당 조건을 충족하면 해결될 Error
+* UnknownError - 위 2가지와 관련되지 않은 Error
+*/
+sealed class ErrorEntity {
+    object RetryableError: ErrorEntity()
+    object ConditionalError: ErrorEntity()
+    object UnknownError: ErrorEntity()
+}

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/entity/result/CustomResult.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/entity/result/CustomResult.kt
@@ -1,0 +1,8 @@
+package co.kr.woowahan_banchan.domain.entity.result
+
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+
+sealed class CustomResult<T> {
+    data class Success<T>(val data: T): CustomResult<T>()
+    data class Error<T>(val error: ErrorEntity): CustomResult<T>()
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #105 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] sealed class CustomResult 추가

### 참고사항
기존의 Result에는 이런 companion object가 있다네.

> 
    /**
     * Companion object for [Result] class that contains its constructor functions
     * [success] and [failure].
     */
    public companion object {
        /**
         * Returns an instance that encapsulates the given [value] as successful value.
         */
        @Suppress("INAPPLICABLE_JVM_NAME")
        @InlineOnly
        @JvmName("success")
        public inline fun <T> success(value: T): Result<T> =
            Result(value)

        /**
         * Returns an instance that encapsulates the given [Throwable] [exception] as failure.
         */
        @Suppress("INAPPLICABLE_JVM_NAME")
        @InlineOnly
        @JvmName("failure")
        public inline fun <T> failure(exception: Throwable): Result<T> =
            Result(createFailure(exception))
    }

오늘 논의한대로, 기존의 Result 클래스는 우리의 ErrorEntity를 failure로 받아들이지 못한다네. 왜냐면 Throwable을 받기 때문이지. 그래서 새로운 CustomResult를 추가했다네.