### PR TITLE
[FEATURE] DataSource 리턴타입이 Flow가 아닌 메서드의 예외처리 방식을 runCatchingErrorEntity로 변경

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
@@ -31,14 +31,14 @@ class CartDataSourceImpl @Inject constructor(
 
     override suspend fun deleteItems(ids: List<String>): Result<Unit> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 cartDao.deleteItems(ids)
             }
         }
 
     override suspend fun getAmount(hash: String): Result<Int> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 cartDao.getAmount(hash)
             }
         }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.local.history
 
 import co.kr.woowahan_banchan.data.database.dao.HistoryDao
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.local.HistoryDto
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -29,12 +30,13 @@ class HistoryDataSourceImpl @Inject constructor(
                 emit(listOf())
             }.flowOn(coroutineDispatcher)
 
-    override suspend fun insertItem(hash: String, name: String) =
-        withContext(coroutineDispatcher) {
-            runCatching {
+    override suspend fun insertItem(hash: String, name: String): Result<Unit> {
+        return withContext(coroutineDispatcher) {
+            runCatchingErrorEntity {
                 historyDao.insertItem(
                     HistoryDto(hash, Date().time, name)
                 )
             }
         }
+    }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.local.order
 
 import co.kr.woowahan_banchan.data.database.dao.OrderDao
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.local.OrderDto
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.*
@@ -14,7 +15,7 @@ class OrderDataSourceImpl @Inject constructor(
 ) : OrderDataSource {
     override suspend fun getItems(): Result<List<OrderDto>> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderDao.getItems()
             }
         }
@@ -29,14 +30,14 @@ class OrderDataSourceImpl @Inject constructor(
 
     override suspend fun getTime(orderId: Long): Result<Long> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderDao.getTime(orderId)
             }
         }
 
     override suspend fun insertItem(item: OrderDto): Result<Long> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderDao.insertItem(item)
             }
         }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.local.orderitem
 
 import co.kr.woowahan_banchan.data.database.dao.OrderItemDao
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.local.OrderItemDto
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -12,28 +13,28 @@ class OrderItemDataSourceImpl @Inject constructor(
 ) : OrderItemDataSource {
     override suspend fun getItems(orderId: Long): Result<List<OrderItemDto>> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderItemDao.getItems(orderId)
             }
         }
 
     override suspend fun getItem(orderId: Long): Result<OrderItemDto> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderItemDao.getItem(orderId)
             }
         }
 
     override suspend fun getItemCount(orderId: Long): Result<Int> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderItemDao.getItemCount(orderId)
             }
         }
 
     override suspend fun insertItems(items: List<OrderItemDto>): Result<Unit> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 orderItemDao.insertItems(items)
             }
         }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/best/BestDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/best/BestDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.remote.best
 
 import co.kr.woowahan_banchan.data.api.BestService
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.BestResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,14 +10,10 @@ class BestDataSourceImpl(
     private val service: BestService,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : BestDataSource {
-
     override suspend fun getBests(): Result<List<BestResponse>> =
         withContext(coroutineDispatcher) {
-            runCatching {
-                val response = service.getBests()
-                if (response.statusCode != 200) return@withContext Result.failure(Exception("network err"))
-                val body = response.body ?: return@withContext Result.failure(Exception("null response"))
-                body
+            runCatchingErrorEntity {
+                service.getBests().body
             }
         }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/detail/DetailDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/detail/DetailDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.remote.detail
 
 import co.kr.woowahan_banchan.data.api.DetailService
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,10 +10,9 @@ class DetailDataSourceImpl(
     private val service: DetailService,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : DetailDataSource {
-
     override suspend fun getDetail(hash: String): Result<DetailResponse> =
         withContext(coroutineDispatcher) {
-            runCatching {
+            runCatchingErrorEntity {
                 service.getDetail(hash)
             }
         }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/maindish/MainDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/maindish/MainDishDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.remote.maindish
 
 import co.kr.woowahan_banchan.data.api.MainDishService
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,14 +10,10 @@ class MainDishDataSourceImpl(
     private val service: MainDishService,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : MainDishDataSource {
-
     override suspend fun getMainDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {
-            runCatching {
-                val response = service.getMainDishes()
-                if (response.statusCode != 200) return@withContext Result.failure(Exception("network err"))
-                val body = response.body ?: return@withContext Result.failure(Exception("null response"))
-                body
+            runCatchingErrorEntity {
+                service.getMainDishes().body
             }
         }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/sidedish/SideDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/sidedish/SideDishDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.remote.sidedish
 
 import co.kr.woowahan_banchan.data.api.SideDishService
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,14 +10,10 @@ class SideDishDataSourceImpl(
     private val service: SideDishService,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : SideDishDataSource {
-
     override suspend fun getSideDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {
-            runCatching {
-                val response = service.getSideDishes()
-                if (response.statusCode != 200) return@withContext Result.failure(Exception("network err"))
-                val body = response.body ?: return@withContext Result.failure(Exception("null response"))
-                body
+            runCatchingErrorEntity {
+                service.getSideDishes().body
             }
         }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/soupdish/SoupDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/soupdish/SoupDishDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package co.kr.woowahan_banchan.data.datasource.remote.soupdish
 
 import co.kr.woowahan_banchan.data.api.SoupDishService
+import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -9,14 +10,10 @@ class SoupDishDataSourceImpl(
     private val service: SoupDishService,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : SoupDishDataSource {
-
     override suspend fun getSoupDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {
-            runCatching {
-                val response = service.getSoupDishes()
-                if (response.statusCode != 200) return@withContext Result.failure(Exception("network err"))
-                val body = response.body ?: return@withContext Result.failure(Exception("null response"))
-                body
+            runCatchingErrorEntity {
+                service.getSoupDishes().body
             }
         }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/model/remote/response/ApiResponse.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/model/remote/response/ApiResponse.kt
@@ -2,5 +2,5 @@ package co.kr.woowahan_banchan.data.model.remote.response
 
 data class ApiResponse<T>(
     val statusCode : Int,
-    val body : T? = null,
+    val body : T,
 )


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #105 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] DataSource 리턴타입이 Flow가 아닌 메서드의 예외처리 방식을 runCatchingErrorEntity로 변경
- [x] ApiRespone body 타입을 T?에서 T로 수정

