### PR TITLE
[FEATURE] UseCase의 리턴타입이 Flow가 아닌 메서드의 예외처리 방식을 runCatchingErrorEntity로 변경 및 runCatchingErrorEntity 내부 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/extension/ErrorExtension.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/extension/ErrorExtension.kt
@@ -14,6 +14,7 @@ inline fun <T, R> T.runCatchingErrorEntity(block: T.() -> R): Result<R> {
         Result.success(block())
     } catch (e: Throwable) {
         val error = when (e) {
+            is ErrorEntity -> e
             is HttpRetryException, is InterruptedIOException, is InterruptedByTimeoutException -> ErrorEntity.RetryableError
             is UnknownHostException -> ErrorEntity.ConditionalError
             is IOException -> ErrorEntity.UnknownError

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/DishRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/DishRepositoryImpl.kt
@@ -5,7 +5,6 @@ import co.kr.woowahan_banchan.data.datasource.remote.best.BestDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.maindish.MainDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.sidedish.SideDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.soupdish.SoupDishDataSource
-import co.kr.woowahan_banchan.data.model.local.CartDto
 import co.kr.woowahan_banchan.domain.entity.dish.BestItem
 import co.kr.woowahan_banchan.domain.entity.dish.Dish
 import co.kr.woowahan_banchan.domain.repository.DishRepository
@@ -14,7 +13,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import java.util.*
 import javax.inject.Inject
 
 class DishRepositoryImpl @Inject constructor(

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
@@ -3,7 +3,6 @@ package co.kr.woowahan_banchan.data.repository
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
-import co.kr.woowahan_banchan.data.model.local.HistoryDto
 import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import co.kr.woowahan_banchan.domain.repository.HistoryRepository
 import kotlinx.coroutines.CoroutineDispatcher

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/OrderHistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/OrderHistoryRepositoryImpl.kt
@@ -2,7 +2,6 @@ package co.kr.woowahan_banchan.data.repository
 
 import co.kr.woowahan_banchan.data.datasource.local.order.OrderDataSource
 import co.kr.woowahan_banchan.data.datasource.local.orderitem.OrderItemDataSource
-import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.local.OrderDto
 import co.kr.woowahan_banchan.data.model.local.OrderItemDto
 import co.kr.woowahan_banchan.domain.entity.cart.CartItem
@@ -51,16 +50,15 @@ class OrderHistoryRepositoryImpl @Inject constructor(
 
     override suspend fun getOrderReceipt(orderId: Long): Result<List<OrderItem>> {
         return withContext(coroutineDispatcher) {
-            runCatchingErrorEntity {
-                orderItemDataSource.getItems(orderId).getOrThrow().map {
-                    it.toOrderItem()
+            orderItemDataSource.getItems(orderId)
+                .mapCatching { orderItemsDto ->
+                    orderItemsDto.map { it.toOrderItem() }
                 }
-            }
         }
     }
 
     override suspend fun insertOrderItems(orderItems: List<CartItem>): Result<Long> {
-        return runCatchingErrorEntity {
+        return runCatching {
             val orderId = orderDataSource.insertItem(
                 OrderDto(totalPrice = orderItems.sumOf { it.price }, time = Date().time)
             ).getOrThrow()

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/HistoryAddUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/HistoryAddUseCase.kt
@@ -7,7 +7,5 @@ class HistoryAddUseCase @Inject constructor(
     private val historyRepository: HistoryRepository
 ) {
     suspend operator fun invoke(hash: String, name: String): Result<Unit> =
-        runCatching {
-            historyRepository.addToHistory(hash, name)
-        }
+        historyRepository.addToHistory(hash, name)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderDetailUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderDetailUseCase.kt
@@ -8,7 +8,5 @@ class OrderDetailUseCase @Inject constructor(
     private val orderHistoryRepository: OrderHistoryRepository
 ) {
     suspend operator fun invoke(orderId: Long): Result<List<OrderItem>> =
-        orderHistoryRepository.getOrderReceipt(orderId)?.let {
-            Result.success(it)
-        } ?: Result.failure(Exception("문제가 발생했습니다"))
+        orderHistoryRepository.getOrderReceipt(orderId)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderListUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderListUseCase.kt
@@ -8,7 +8,5 @@ class OrderListUseCase @Inject constructor(
     private val orderHistoryRepository: OrderHistoryRepository
 ) {
     suspend operator fun invoke(): Result<List<OrderHistory>> =
-        runCatching {
-            orderHistoryRepository.getOrderHistories()
-        }
+        orderHistoryRepository.getOrderHistories()
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderTimeUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/OrderTimeUseCase.kt
@@ -7,7 +7,5 @@ class OrderTimeUseCase @Inject constructor(
     private val orderHistoryRepository: OrderHistoryRepository
 ) {
     suspend operator fun invoke(orderId: Long): Result<Long> =
-        runCatching {
-            orderHistoryRepository.getOrderTime(orderId)
-        }
+        orderHistoryRepository.getOrderTime(orderId)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/ProductDetailUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/ProductDetailUseCase.kt
@@ -7,9 +7,6 @@ import javax.inject.Inject
 class ProductDetailUseCase @Inject constructor(
     private val detailRepository: DetailRepository
 ) {
-    suspend operator fun invoke(hash: String): Result<DishInfo> {
-        return detailRepository.getDishInfo(hash)?.let {
-            Result.success(it)
-        } ?: Result.failure(IllegalStateException("상품을 불러오지 못했습니다"))
-    }
+    suspend operator fun invoke(hash: String): Result<DishInfo> =
+        detailRepository.getDishInfo(hash)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/UpdateCartItemsUseCase.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/domain/usecase/UpdateCartItemsUseCase.kt
@@ -7,20 +7,23 @@ import javax.inject.Inject
 class UpdateCartItemsUseCase @Inject constructor(
     private val cartRepository: CartRepository
 ) {
-    suspend operator fun invoke(oldItems : List<CartItem>, cartItems : List<CartItem>) : Result<Unit>{
+    suspend operator fun invoke(oldItems: List<CartItem>, cartItems: List<CartItem>): Result<Unit> {
         return runCatching {
-            val updateItem = mutableListOf<CartItem>()
-            val deleteItem = mutableListOf<String>()
+            val updateItems = mutableListOf<CartItem>()
+            val deleteItems = mutableListOf<String>()
             oldItems.forEach { oldItem ->
-                val temp = cartItems.find{it.hash == oldItem.hash}
+                val findResult = cartItems.find { it.hash == oldItem.hash }
                 when {
-                    temp == null -> deleteItem.add(oldItem.hash)
-                    oldItem.amount != temp.amount ||
-                    oldItem.isSelected != temp.isSelected -> updateItem.add(temp)
+                    findResult == null -> {
+                        deleteItems.add(oldItem.hash)
+                    }
+                    oldItem.amount != findResult.amount || oldItem.isSelected != findResult.isSelected -> {
+                        updateItems.add(findResult)
+                    }
                 }
             }
-            cartRepository.updateCartItems(updateItem)
-            cartRepository.deleteCartItems(deleteItem)
+            cartRepository.updateCartItems(updateItems).getOrThrow()
+            cartRepository.deleteCartItems(deleteItems).getOrThrow()
         }
     }
 }


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #105 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] UseCase의 리턴타입이 Flow가 아닌 메서드의 예외처리 방식을 runCatchingErrorEntity로 변경
- [x] runCatchingErrorEntity 내부 수정
- [x] 불필요한 위치에서 호출되는 runCatchingErrorEntity를 runCatching으로 대체

### 확인사항

이보게 @Skipancho , 예외처리 여정이 이제 거의 끝을 향해 가는 것 같아 보이네. (물론 아직 Flow에 대한 깊이 있는 예외처리는 하지 못했지만 말일세.)

최근 내 온 신경은 Error였다네. <s>(Error 모르겠다 ~)</s> 어떻게 DataSource에서 발생한 Error를 별도의 방해 혹은 간섭 혹은 왜곡 없이, Presentation까지 전달할 수 있을지에 대해 아주 끙끙 고민했던 것 같군. 특히 최근 3일간은 Error Handling에만 몰두했던 것 같네.

요약해서 말하자면, 그동안 `잘 만들었다`고 생각했던 `runCatchingErrorEntity`에는 내 치명적인 실수가 하나 있었네. 혹시 자네는 눈치챘는가? 아마도 자네도 눈치채지 못했을 것이야. 먼저 코드를 같이 봅세.

``` kotlin
inline fun <T, R> T.runCatchingErrorEntity(block: T.() -> R): Result<R> {
    return try {
        Result.success(block())
    } catch (e: Throwable) {
        val error = when (e) {
            is HttpRetryException, is InterruptedIOException, is InterruptedByTimeoutException -> ErrorEntity.RetryableError
            is UnknownHostException -> ErrorEntity.ConditionalError
            is IOException -> ErrorEntity.UnknownError
            is HttpException -> {
                when (e.code()) {
                    HttpURLConnection.HTTP_CLIENT_TIMEOUT, HttpURLConnection.HTTP_GATEWAY_TIMEOUT -> ErrorEntity.RetryableError
                    else -> ErrorEntity.UnknownError
                }
            }
            else -> ErrorEntity.UnknownError
        }
        Result.failure(error)
    }
}
```

블록을 실행하고, 예외가 발생할 경우 나름 우리의 기준대로 Throwable을 분류하는 `runCatchingErrorEntity` 코드일세. 나는 이 코드를 DataSource에서 `runCatching` 대신 `runCatchingErrorEntity`를 사용했고, 이를 통해 `Result` 클래스가 우리의 `ErrorEntity`를 담을 수 있도록 했네.

하지만 문제가 있었지. 바로, runCatching을 `Repository`나 `UseCase`에서 사용할 경우 `DataSource`에서 발생한 ErrorEntity가 전파되지 않는다는 것이야. 정말 바보같았네.

**우리는 `runCatchingErrorEntity`의 catch 블록에 인자로 우리의 `ErrorEntity`가 들어갈 것을 생각하지 못했네.**

그래서 DataSource에서 백날 `RetryableError`나 `ConditionalError`가 발생해도 Repository나 UseCase에서는 `UnknownError`가 나왔던 것일세. 이 부분을 고쳤네.

이를 활용해서, 우리는 기존 Repository나 UseCase에서 문제없이 DataSource의 메서드를 호출할 수 있네. 바로 `getOrThrow()` 메서드를 통해서 말이야.

``` kotlin
@InlineOnly
@SinceKotlin("1.3")
public inline fun <T> Result<T>.getOrThrow(): T {
    throwOnFailure()
    return value as T
}
```

``` kotlin
@PublishedApi
@SinceKotlin("1.3")
internal fun Result<*>.throwOnFailure() {
    if (value is Result.Failure) throw value.exception
}
```

`getOrThrow()` 메서드의 내부 구조일세. Result 클래스의 value가 Failure일 경우, value에 들어간 exception을 throw하지.
우리는 `runCatchingErrorEntity`에서 `Result.failure(exception: Throwable)` 형태로 Throwable을 처리하지.

``` kotlin
@Suppress("INAPPLICABLE_JVM_NAME")
@InlineOnly
@JvmName("failure")
public inline fun <T> failure(exception: Throwable): Result<T> =
    Result(createFailure(exception))
```

``` kotlin
@PublishedApi
@SinceKotlin("1.3")
internal fun createFailure(exception: Throwable): Any =
    Result.Failure(exception)
```

이를 통해 보면 알 수 있는데, 우리가 넣은 exception 그대로를 `getOrThrow()`가 꺼내는 것일세. 그래서 전 PR에서 했던, Repository의 runCatching들을 runCatchingErrorEntity로 바꾼 것은 의미가 없네. throw되는 Throwable은 우리의 `ErrorEntity`이기 때문이지.

말이 조금 어려웠을 수도 있겠다는 생각에 자세하게 설명해봤네. 예외처리를 다뤄보면서, 나는 정말 많은 것을 배웠던 것 같네. 내가 배운 것들을 자네에게도 공유하고 싶어 매번 PR이 이렇게 길다는 점, 이해해주면 좋겠네. 우리는 코딩깐부니까.

그럼, 자네의 오랜 친구 @hansh0101 (Iceman)이.

p.s. 오늘 루터회관에 사람이 없어서 그런지 정수기에서 얼음이 잘 나오더군. 난 오늘 약 52개의 얼음을 깨부순 것 같네. 내 이빨로 말이야. 🦷