### PR TITLE
[FEATURE] LocalDataSourceImpl 테스트 코드 작성

### DIFF
--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImplTest.kt
@@ -131,6 +131,7 @@ class FakeCartDaoWithError(
     initCartDtos: List<CartDto> = listOf()
 ) : CartDao {
     val cartDtos = initCartDtos.toMutableList()
+
     override fun getItems(): Flow<List<CartDto>> {
         return flow { throw InterruptedIOException() }
     }

--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
@@ -136,6 +136,8 @@ class FakeHistoryDao(
 class FakeHistoryDaoWithError(
     initHistoryDtos: List<HistoryDto>
 ) : HistoryDao {
+    val orderHistoryDtos = initHistoryDtos.toMutableList()
+
     override fun getItems(): Flow<List<HistoryDto>> {
         return flow { throw InterruptedByTimeoutException().toErrorEntity() }
     }

--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
@@ -1,0 +1,150 @@
+package co.kr.woowahan_banchan.data.datasource.local.history
+
+import co.kr.woowahan_banchan.data.database.dao.HistoryDao
+import co.kr.woowahan_banchan.data.extension.toErrorEntity
+import co.kr.woowahan_banchan.data.model.local.HistoryDto
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.InterruptedIOException
+import java.nio.channels.InterruptedByTimeoutException
+
+@ExperimentalCoroutinesApi
+class HistoryDataSourceImplTest {
+    private val historyDto1 = HistoryDto("A", 0, "item0")
+    private val historyDto2 = HistoryDto("B", 1, "item1")
+    private val historyDto3 = HistoryDto("C", 2, "item2")
+    private val historyDto4 = HistoryDto("D", 3, "item3")
+    private val historyDto5 = HistoryDto("E", 4, "item4")
+    private val historyDto6 = HistoryDto("F", 5, "item5")
+    private val historyDto7 = HistoryDto("G", 6, "item6")
+    private val historyDto8 = HistoryDto("H", 7, "item7")
+    private val originalHistoryDtos = listOf(
+        historyDto1,
+        historyDto2,
+        historyDto3,
+        historyDto4,
+        historyDto5,
+        historyDto6,
+        historyDto7,
+        historyDto8
+    )
+
+    private lateinit var historyDao: FakeHistoryDao
+    private lateinit var historyDataSource: HistoryDataSource
+    private lateinit var historyDaoWithError: FakeHistoryDaoWithError
+    private lateinit var historyDataSourceWithError: HistoryDataSource
+
+    @Before
+    fun setUp() {
+        historyDao = FakeHistoryDao(originalHistoryDtos)
+        historyDataSource = HistoryDataSourceImpl(historyDao, UnconfinedTestDispatcher())
+        historyDaoWithError = FakeHistoryDaoWithError(originalHistoryDtos)
+        historyDataSourceWithError =
+            HistoryDataSourceImpl(historyDaoWithError, UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun getItems() = runTest {
+        val expected = historyDao.historyDtos
+        var actual: List<HistoryDto>? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            historyDataSource.getItems().collect { actual = it }
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun getItemsWithError() = runTest {
+        val expected = Result.failure<List<HistoryDto>>(ErrorEntity.RetryableError)
+        var actual: Result<List<HistoryDto>>? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            historyDaoWithError.getItems()
+                .catch { actual = Result.failure(it) }
+                .collect {}
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun getPreviewItems() = runTest {
+        val expected = historyDao.historyDtos.take(7)
+        var actual: List<HistoryDto>? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            historyDataSource.getPreviewItems().collect { actual = it }
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun getPreviewItemsWithError() = runTest {
+        val expected = Result.failure<List<HistoryDto>>(ErrorEntity.RetryableError)
+        var actual: Result<List<HistoryDto>>? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            historyDataSourceWithError.getPreviewItems()
+                .catch { actual = Result.failure(it) }
+                .collect {}
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun insertItem() = runTest {
+        val expected = Result.success(Unit)
+        val actual = historyDataSource.insertItem("I", "item8")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertItemWithError() = runTest {
+        val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+        val actual = historyDataSourceWithError.insertItem("I", "item8")
+        assertEquals(expected, actual)
+    }
+}
+
+class FakeHistoryDao(
+    initHistoryDtos: List<HistoryDto> = listOf()
+) : HistoryDao {
+    val historyDtos = initHistoryDtos.toMutableList()
+
+    override fun getItems(): Flow<List<HistoryDto>> {
+        return flow { emit(historyDtos) }
+    }
+
+    override fun getPreviewItems(): Flow<List<HistoryDto>> {
+        return flow { emit(historyDtos.apply { sortWith(compareBy { it.time }) }.take(7)) }
+    }
+
+    override suspend fun insertItem(item: HistoryDto) {
+        return
+    }
+}
+
+class FakeHistoryDaoWithError(
+    initHistoryDtos: List<HistoryDto>
+) : HistoryDao {
+    override fun getItems(): Flow<List<HistoryDto>> {
+        return flow { throw InterruptedByTimeoutException().toErrorEntity() }
+    }
+
+    override fun getPreviewItems(): Flow<List<HistoryDto>> {
+        return flow { throw InterruptedIOException().toErrorEntity() }
+    }
+
+    override suspend fun insertItem(item: HistoryDto) {
+        throw IllegalStateException()
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImplTest.kt
@@ -1,0 +1,147 @@
+package co.kr.woowahan_banchan.data.datasource.local.order
+
+import co.kr.woowahan_banchan.data.database.dao.OrderDao
+import co.kr.woowahan_banchan.data.model.local.OrderDto
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+@ExperimentalCoroutinesApi
+class OrderDataSourceImplTest {
+    private val orderDto1 = OrderDto(1, 6000, 1661073342694)
+    private val orderDto2 = OrderDto(2, 11800, 1661073350797)
+    private val orderDto3 = OrderDto(3, 28110, 1661073395292)
+    private val originalOrderDtos = listOf(orderDto1, orderDto2)
+
+    private lateinit var orderDao: FakeOrderDao
+    private lateinit var orderDataSource: OrderDataSource
+    private lateinit var orderDaoWithError: FakeOrderDaoWithError
+    private lateinit var orderDataSourceWithError: OrderDataSource
+
+    @Before
+    fun setUp() {
+        orderDao = FakeOrderDao(originalOrderDtos)
+        orderDataSource = OrderDataSourceImpl(orderDao, UnconfinedTestDispatcher())
+        orderDaoWithError = FakeOrderDaoWithError(originalOrderDtos)
+        orderDataSourceWithError =
+            OrderDataSourceImpl(orderDaoWithError, UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun getItems() = runTest {
+        val expected = Result.success(orderDao.orderDtos)
+        val actual = orderDataSource.getItems()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItemsWithError() = runTest {
+        val expected = Result.failure<List<OrderDto>>(ErrorEntity.UnknownError)
+        val actual = orderDataSourceWithError.getItems()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getLatestOrderTime() = runTest {
+        val expected =
+            orderDao.orderDtos.apply { sortWith(compareByDescending { it.time }) }.first().time
+        var actual: Long? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            orderDataSource.getLatestOrderTime().collect { actual = it }
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun getLatestOrderTimeWithError() = runTest {
+        val expected = Result.failure<Long>(ErrorEntity.UnknownError)
+        var actual: Result<Long>? = null
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            orderDataSourceWithError.getLatestOrderTime()
+                .catch { actual = Result.failure(it) }
+                .collect {}
+        }
+        assertEquals(expected, actual)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun getTime() = runTest {
+        val expected = Result.success(requireNotNull(orderDao.orderDtos.find { it.id == 2L }).time)
+        val actual = orderDataSource.getTime(2L)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getTimeWithError() = runTest {
+        val expected = Result.failure<Long>(ErrorEntity.UnknownError)
+        val actual = orderDataSourceWithError.getTime(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertItem() = runTest {
+        val expected = Result.success(3L)
+        val actual = orderDataSource.insertItem(orderDto3)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertItemWithError() = runTest {
+        val expected = Result.failure<Long>(ErrorEntity.UnknownError)
+        val actual = orderDataSourceWithError.insertItem(orderDto3)
+        assertEquals(expected, actual)
+    }
+}
+
+class FakeOrderDao(initOrderDtos: List<OrderDto>) : OrderDao {
+    val orderDtos = initOrderDtos.toMutableList()
+
+    override suspend fun getItems(): List<OrderDto> {
+        return orderDtos
+    }
+
+    override fun getLatestOrderTime(): Flow<Long> {
+        return flow {
+            emit(orderDtos.apply { sortWith(compareByDescending { it.time }) }.first().time)
+        }
+    }
+
+    override suspend fun getTime(orderId: Long): Long {
+        return requireNotNull(orderDtos.find { it.id == orderId }).time
+    }
+
+    override suspend fun insertItem(item: OrderDto): Long {
+        return (orderDtos.size + 1).toLong()
+    }
+}
+
+class FakeOrderDaoWithError(initOrderDtos: List<OrderDto>) : OrderDao {
+    val orderDtos = initOrderDtos.toMutableList()
+
+    override suspend fun getItems(): List<OrderDto> {
+        throw IllegalStateException()
+    }
+
+    override fun getLatestOrderTime(): Flow<Long> {
+        return flow { throw ArithmeticException() }
+    }
+
+    override suspend fun getTime(orderId: Long): Long {
+        throw IOException()
+    }
+
+    override suspend fun insertItem(item: OrderDto): Long {
+        throw NullPointerException()
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImplTest.kt
@@ -1,0 +1,159 @@
+package co.kr.woowahan_banchan.data.datasource.local.orderitem
+
+import co.kr.woowahan_banchan.data.database.dao.OrderItemDao
+import co.kr.woowahan_banchan.data.model.local.OrderItemDto
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+import java.net.UnknownHostException
+
+@ExperimentalCoroutinesApi
+class OrderItemDataSourceImplTest {
+    private val orderItemDto1 = OrderItemDto(
+        1,
+        1,
+        "HBBCC",
+        "http://public.codesquad.kr/jk/storeapp/data/side/48_ZIP_P_5008_T.jpg",
+        6000,
+        2,
+        "새콤달콤 오징어무침"
+    )
+    private val orderItemDto2 = OrderItemDto(
+        2,
+        2,
+        "H1AA9",
+        "http://public.codesquad.kr/jk/storeapp/data/main/739_ZIP_P__T.jpg",
+        11800,
+        3,
+        "초계국수_쿠킹박스"
+    )
+    private val orderItemDto3 = OrderItemDto(
+        3,
+        3,
+        "H26C7",
+        "http://public.codesquad.kr/jk/storeapp/data/soup/818_ZIP_P_1033_T.jpg",
+        11900,
+        1,
+        "순한 오징어무국"
+    )
+    private val originalOrderItemDtos = listOf(orderItemDto1, orderItemDto2)
+
+    private lateinit var orderItemDao: FakeOrderItemDao
+    private lateinit var orderItemDataSource: OrderItemDataSource
+    private lateinit var orderItemDaoWithError: FakeOrderItemDaoWithError
+    private lateinit var orderItemDataSourceWithError: OrderItemDataSource
+
+    @Before
+    fun setUp() {
+        orderItemDao = FakeOrderItemDao(originalOrderItemDtos)
+        orderItemDataSource = OrderItemDataSourceImpl(orderItemDao, UnconfinedTestDispatcher())
+        orderItemDaoWithError = FakeOrderItemDaoWithError(originalOrderItemDtos)
+        orderItemDataSourceWithError =
+            OrderItemDataSourceImpl(orderItemDaoWithError, UnconfinedTestDispatcher())
+    }
+
+    @Test
+    fun getItems() = runTest {
+        val expected = Result.success(originalOrderItemDtos.filter { it.orderId == 1L })
+        val actual = orderItemDataSource.getItems(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItemsWithError() = runTest {
+        val expected = Result.failure<List<OrderItemDto>>(ErrorEntity.UnknownError)
+        val actual = orderItemDataSourceWithError.getItems(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItem() = runTest {
+        val expected = Result.success(orderItemDao.orderItemDtos.first { it.orderId == 1L })
+        val actual = orderItemDataSource.getItem(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItemWithError() = runTest {
+        val expected = Result.failure<OrderItemDto>(ErrorEntity.ConditionalError)
+        val actual = orderItemDataSourceWithError.getItem(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItemCount() = runTest {
+        val expected = Result.success(orderItemDao.orderItemDtos.filter { it.orderId == 1L }.size)
+        val actual = orderItemDataSource.getItemCount(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getItemCountWithError() = runTest {
+        val expected = Result.failure<Int>(ErrorEntity.UnknownError)
+        val actual = orderItemDataSourceWithError.getItemCount(1)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertItems() = runTest {
+        val expected = Result.success(Unit)
+        val actual = orderItemDataSource.insertItems(listOf(orderItemDto3))
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun insertItemsWithError() = runTest {
+        val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+        val actual = orderItemDataSourceWithError.insertItems(listOf(orderItemDto3))
+        assertEquals(expected, actual)
+    }
+}
+
+class FakeOrderItemDao(
+    initOrderItemDtos: List<OrderItemDto>
+) : OrderItemDao {
+    val orderItemDtos = initOrderItemDtos.toMutableList()
+
+    override suspend fun getItems(orderId: Long): List<OrderItemDto> {
+        return orderItemDtos.filter { it.orderId == orderId }
+    }
+
+    override suspend fun getItem(orderId: Long): OrderItemDto {
+        return orderItemDtos.first { it.orderId == orderId }
+    }
+
+    override suspend fun getItemCount(orderId: Long): Int {
+        return orderItemDtos.filter { it.orderId == orderId }.size
+    }
+
+    override suspend fun insertItems(items: List<OrderItemDto>) {
+        return
+    }
+}
+
+class FakeOrderItemDaoWithError(
+    initOrderItemDtos: List<OrderItemDto>
+) : OrderItemDao {
+    val orderItemDtos = initOrderItemDtos.toMutableList()
+
+    override suspend fun getItems(orderId: Long): List<OrderItemDto> {
+        throw IOException()
+    }
+
+    override suspend fun getItem(orderId: Long): OrderItemDto {
+        throw UnknownHostException()
+    }
+
+    override suspend fun getItemCount(orderId: Long): Int {
+        throw IllegalThreadStateException()
+    }
+
+    override suspend fun insertItems(items: List<OrderItemDto>) {
+        throw ArrayIndexOutOfBoundsException()
+    }
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #125 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] CartDataSourceImpl 테스트 코드 작성
- [x] HistoryDataSourceImpl 테스트 코드 작성
- [x] OrderDataSourceImpl 테스트 코드 작성
- [x] OrderItemDataSourceImpl 테스트 코드 작성

### 참고사항

@Skipancho , 테스트 코드란 무엇일까?
일단은 하던 작업을 마저 하고 나중에 수정을 하는 편이 나을 것 같아 먼저 PR을 날리네.
퇴근 직전 우리가 하던 대화이기도 하지만, 나는 Flow 관련 예외처리를 지금 throw만 하고 있다네.
그래서 뭔가 테스트 코드를 작성하면서 이상하다고 느꼈어.

나는 DataSourceImpl의 코드가 우리의 의도대로 동작하는지를 테스트하는 것인데, throw를 하는 메서드를 테스트하는 것이 맞는지에 대한 의문이 첫 번째이고,
두 번째는 우리가 정하기론 DataSource에서 발생한 에러를 우리의 에러 타입으로 분류해 Repository에 넘기기로 하지 않았나?

우리가 정한 것을 내가 어긴 것 같은 느낌을 지울 수 없네.
하지만 우선 하던 작업은 마무리한 뒤, 고치는 편이 나을 것이라 판단했네.
우리는 이미 git revert로 한 번 고생을 하지 않았나.
이 중요한 막판에 git이 꼬이는 것보다는, 차라리 내 코드를 수정해 다시 커밋하는 편이 낫다고 판단했네.

내가 오늘 밤에 한 번 어떻게 Flow에 대해 예외처리를 해야 적합한 것일지, 고민을 해보겠네.

자네도 의견이 생긴다면 바로바로 슬랙을 통해, 혹은 여기 코멘트를 통해 알려주게.

close #125 