### PR TITLE
[FEATURE] CartRepository Test Code 작성

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
@@ -38,7 +38,7 @@ class CartRepositoryImpl @Inject constructor(
     override fun getCartItemCount(): Flow<Result<Int>> {
         return cartDataSource.getItems()
             .map { Result.success(it.size) }
-            .catch { Result.failure<Throwable>(it) }
+            .catch { emit(Result.failure(it)) }
     }
 
     override fun getCartItems(): Flow<Result<List<CartItem>>> {

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
@@ -1,0 +1,175 @@
+package co.kr.woowahan_banchan.data.repository
+
+import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
+import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeCartDataSource
+import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeCartDataSourceWithError
+import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeDetailDataSource
+import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeDetailDataSourceWithError
+import co.kr.woowahan_banchan.domain.entity.cart.CartItem
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import co.kr.woowahan_banchan.domain.repository.CartRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class CartRepositoryImplTest {
+
+    private val cartItem = CartItem("HF778", "소갈비찜", true, 1, "", 26010)
+
+    private lateinit var cartDataSource: CartDataSource
+    private lateinit var cartDataSourceWithError: CartDataSource
+
+    private lateinit var detailDataSource: DetailDataSource
+    private lateinit var detailDataSourceWithError: DetailDataSource
+
+    private lateinit var cartRepository: CartRepository
+    private lateinit var cartRepositoryWithError: CartRepository
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        cartDataSource = FakeCartDataSource()
+        cartDataSourceWithError = FakeCartDataSourceWithError()
+        detailDataSource = FakeDetailDataSource()
+        detailDataSourceWithError = FakeDetailDataSourceWithError()
+        cartRepository = CartRepositoryImpl(cartDataSource, detailDataSource, testDispatcher)
+        cartRepositoryWithError = CartRepositoryImpl(cartDataSourceWithError, detailDataSourceWithError, testDispatcher)
+    }
+
+    @Test
+    fun addToCartTest() {
+        runTest {
+            val expected = Result.success(Unit)
+            val actual = cartRepository.addToCart("HF778", 1, "소갈비찜")
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun updateCartItemsTest() {
+        runTest {
+            val expected = Result.success(Unit)
+            val actual = cartRepository.updateCartItems(
+                listOf(
+                    cartItem
+                )
+            )
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun deleteCartItemsTest() {
+        runTest {
+            val expected = Result.success(Unit)
+            val actual = cartRepository.deleteCartItems(listOf(cartItem.hash))
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun getCartItemCountTest() {
+        runTest {
+            val expected = Result.success(1)
+            var actual: Result<Int>? = null
+            val collectJob = launch(UnconfinedTestDispatcher()) {
+                cartRepository.getCartItemCount().collect {
+                    actual = it
+                }
+            }
+            assertEquals(expected, actual)
+            collectJob.cancel()
+        }
+    }
+
+    @Test
+    fun getCartItemsTest() {
+        runTest {
+            val expected = Result.success(
+                listOf(
+                    CartItem(
+                        hash = "HF778",
+                        name = "소갈비찜",
+                        isSelected = true,
+                        amount = 1,
+                        imageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                        price = 26010
+                    )
+                )
+            )
+            var actual: Result<List<CartItem>>? = null
+            cartRepository.getCartItems().collect {
+                actual = it
+            }
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun addToCartErrorTest() {
+        runTest {
+            val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+            val actual = cartRepositoryWithError.addToCart("HF778", 1, "소갈비찜")
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun updateCartItemsErrorTest() {
+        runTest {
+            val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+            val actual = cartRepositoryWithError.updateCartItems(
+                listOf(
+                    cartItem
+                )
+            )
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun deleteCartItemsErrorTest() {
+        runTest {
+            val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+            val actual = cartRepositoryWithError.deleteCartItems(listOf(cartItem.hash))
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun getCartItemCountErrorTest() {
+        runTest {
+            val expected = Result.failure<Int>(ErrorEntity.UnknownError)
+            var actual: Result<Int>? = null
+            val collectJob = launch(testDispatcher) {
+                cartRepositoryWithError.getCartItemCount().collect {
+                    actual = it
+                }
+            }
+            assertEquals(expected, actual)
+            collectJob.cancel()
+        }
+    }
+
+    @Test
+    fun getCartItemsErrorTest() {
+        runTest {
+            val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+            var actual: Result<List<CartItem>>? = null
+            val collectJob = launch(testDispatcher) {
+                cartRepositoryWithError.getCartItems().collect {
+                    actual = it
+                }
+            }
+            assertEquals(expected, actual)
+            collectJob.cancel()
+        }
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
@@ -190,7 +190,7 @@ class CartRepositoryImplTest {
     @Test
     fun getCartItemsErrorTest() {
         runTest {
-            val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+            val expected = Result.failure<List<CartItem>>(ErrorEntity.UnknownError)
             var actual: Result<List<CartItem>>? = null
             val collectJob = launch(testDispatcher) {
                 cartRepositoryWithError.getCartItems().collect {

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImplTest.kt
@@ -2,6 +2,9 @@ package co.kr.woowahan_banchan.data.repository
 
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.data.model.local.CartDto
+import co.kr.woowahan_banchan.data.model.remote.response.DetailDataResponse
+import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
 import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeCartDataSource
 import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeCartDataSourceWithError
 import co.kr.woowahan_banchan.data.repository.fakedatasource.FakeDetailDataSource
@@ -20,7 +23,32 @@ import org.junit.Test
 @ExperimentalCoroutinesApi
 class CartRepositoryImplTest {
 
+
+    private val cartDto = CartDto("HF778", 1, true, 111111, "소갈비찜")
     private val cartItem = CartItem("HF778", "소갈비찜", true, 1, "", 26010)
+
+    private val cartDtos = listOf(cartDto)
+
+    private val detailResponse = DetailResponse(
+        hash = "HF778",
+        data = DetailDataResponse(
+            topImageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+            thumbnailUrls = listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_S.jpg"
+            ),
+            productDescription = "촉촉하게 밴 양념이 일품",
+            point = "260원",
+            deliveryInfo = "서울 경기 새벽 배송 / 전국 택배 배송",
+            deliveryFee = "2,500원 (40,000원 이상 구매 시 무료)",
+            prices = listOf("28,900원", "26,010원"),
+            detailSection = listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D1.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D2.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/pakage_regular.jpg"
+            )
+        )
+    )
 
     private lateinit var cartDataSource: CartDataSource
     private lateinit var cartDataSourceWithError: CartDataSource
@@ -35,12 +63,13 @@ class CartRepositoryImplTest {
 
     @Before
     fun setUp() {
-        cartDataSource = FakeCartDataSource()
+        cartDataSource = FakeCartDataSource(cartDtos.toMutableList())
         cartDataSourceWithError = FakeCartDataSourceWithError()
-        detailDataSource = FakeDetailDataSource()
+        detailDataSource = FakeDetailDataSource(detailResponse)
         detailDataSourceWithError = FakeDetailDataSourceWithError()
         cartRepository = CartRepositoryImpl(cartDataSource, detailDataSource, testDispatcher)
-        cartRepositoryWithError = CartRepositoryImpl(cartDataSourceWithError, detailDataSourceWithError, testDispatcher)
+        cartRepositoryWithError =
+            CartRepositoryImpl(cartDataSourceWithError, detailDataSourceWithError, testDispatcher)
     }
 
     @Test

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSource.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSource.kt
@@ -1,0 +1,41 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
+import co.kr.woowahan_banchan.data.model.local.CartDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeCartDataSource : CartDataSource {
+    private val cartItems = mutableListOf(
+        CartDto(
+            hash = "HF778",
+            amount = 1,
+            isSelected = true,
+            time = 111111,
+            name = "소갈비찜"
+        )
+    )
+
+    override fun getItems(): Flow<List<CartDto>> {
+        return flow {
+            emit(cartItems)
+        }
+    }
+
+    override suspend fun insertOrUpdateItems(items: List<CartDto>): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun deleteItems(ids: List<String>): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun getAmount(hash: String): Result<Int> {
+        val temp = cartItems.find { it.hash == hash }
+        return if (temp != null) {
+            Result.success(temp.amount)
+        } else {
+            Result.success(0)
+        }
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSource.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSource.kt
@@ -5,20 +5,13 @@ import co.kr.woowahan_banchan.data.model.local.CartDto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class FakeCartDataSource : CartDataSource {
-    private val cartItems = mutableListOf(
-        CartDto(
-            hash = "HF778",
-            amount = 1,
-            isSelected = true,
-            time = 111111,
-            name = "소갈비찜"
-        )
-    )
+class FakeCartDataSource(
+    private val cartDtos : MutableList<CartDto>
+) : CartDataSource {
 
     override fun getItems(): Flow<List<CartDto>> {
         return flow {
-            emit(cartItems)
+            emit(cartDtos)
         }
     }
 
@@ -31,7 +24,7 @@ class FakeCartDataSource : CartDataSource {
     }
 
     override suspend fun getAmount(hash: String): Result<Int> {
-        val temp = cartItems.find { it.hash == hash }
+        val temp = cartDtos.find { it.hash == hash }
         return if (temp != null) {
             Result.success(temp.amount)
         } else {

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSourceWithError.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeCartDataSourceWithError.kt
@@ -1,0 +1,29 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
+import co.kr.woowahan_banchan.data.extension.toErrorEntity
+import co.kr.woowahan_banchan.data.model.local.CartDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import okio.EOFException
+import okio.IOException
+
+class FakeCartDataSourceWithError : CartDataSource {
+    override fun getItems(): Flow<List<CartDto>> {
+        return flow {
+            throw Exception().toErrorEntity()
+        }
+    }
+
+    override suspend fun insertOrUpdateItems(items: List<CartDto>): Result<Unit> {
+        return Result.failure(IOException().toErrorEntity())
+    }
+
+    override suspend fun deleteItems(ids: List<String>): Result<Unit> {
+        return Result.failure(EOFException().toErrorEntity())
+    }
+
+    override suspend fun getAmount(hash: String): Result<Int> {
+        return Result.failure(IllegalStateException().toErrorEntity())
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSource.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSource.kt
@@ -1,0 +1,32 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.data.model.remote.response.DetailDataResponse
+import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
+
+class FakeDetailDataSource : DetailDataSource {
+    override suspend fun getDetail(hash: String): Result<DetailResponse> {
+        return Result.success(
+            DetailResponse(
+                hash = "HF778",
+                data = DetailDataResponse(
+                    topImageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                    thumbnailUrls = listOf(
+                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_S.jpg"
+                    ),
+                    productDescription = "촉촉하게 밴 양념이 일품",
+                    point = "260원",
+                    deliveryInfo = "서울 경기 새벽 배송 / 전국 택배 배송",
+                    deliveryFee = "2,500원 (40,000원 이상 구매 시 무료)",
+                    prices = listOf("28,900원", "26,010원"),
+                    detailSection = listOf(
+                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D1.jpg",
+                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D2.jpg",
+                        "http://public.codesquad.kr/jk/storeapp/data/pakage_regular.jpg"
+                    )
+                )
+            )
+        )
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSource.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSource.kt
@@ -4,29 +4,10 @@ import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
 import co.kr.woowahan_banchan.data.model.remote.response.DetailDataResponse
 import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
 
-class FakeDetailDataSource : DetailDataSource {
+class FakeDetailDataSource(
+    private val detailResponse: DetailResponse
+) : DetailDataSource {
     override suspend fun getDetail(hash: String): Result<DetailResponse> {
-        return Result.success(
-            DetailResponse(
-                hash = "HF778",
-                data = DetailDataResponse(
-                    topImageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
-                    thumbnailUrls = listOf(
-                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
-                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_S.jpg"
-                    ),
-                    productDescription = "촉촉하게 밴 양념이 일품",
-                    point = "260원",
-                    deliveryInfo = "서울 경기 새벽 배송 / 전국 택배 배송",
-                    deliveryFee = "2,500원 (40,000원 이상 구매 시 무료)",
-                    prices = listOf("28,900원", "26,010원"),
-                    detailSection = listOf(
-                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D1.jpg",
-                        "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D2.jpg",
-                        "http://public.codesquad.kr/jk/storeapp/data/pakage_regular.jpg"
-                    )
-                )
-            )
-        )
+        return Result.success(detailResponse)
     }
 }

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSourceWithError.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeDetailDataSourceWithError.kt
@@ -1,0 +1,12 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.data.extension.toErrorEntity
+import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
+import java.net.UnknownHostException
+
+class FakeDetailDataSourceWithError : DetailDataSource {
+    override suspend fun getDetail(hash: String): Result<DetailResponse> {
+        return Result.failure(UnknownHostException().toErrorEntity())
+    }
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #132 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] CartRepository Test Code 작성

close #132

To. 친애하는 Iceman (@hansh0101) 
우선은 진행한 CartRepository 구현체에 대한 테스트 코드를 PR을 날리겠네 
하루 밤 동안 내가 생각한 바로는 단순 throw만 하는 경우 우리는 어떤 에러를 날리겠다는 의도와 함수의 역할을 이미 정해둔 상황에서 그것이 throw를 잘 날리는가?를 테스트하는 것은 크게 의미가 없다는 생각이 들더군 
자네가 고민한 두 번째 고민은 에러타입을 분류해 Repository로 넘기는 것은 지금도 어느 정도 만족을 하고 있는 것 같다네. 나는 이 부분에서 의도와 역할에 조금 중점을 두고 생각했네, 

첫 번째. 우리의 의도는?
-> DataSource에서 또는 이전에서 발생한 에러를 우리가 정의한 에러 타입으로 분류
-> 분류한 에러타입을 Repository로 전달

두 번째. DataSource내의 함수들의 역할은?
-> 발생한 에러를 에러타입으로 분류한다. ( 이 부분은 toErrorEntity()가 해결 )
-> 분류한 에러타입을 Repository로 전달 ( throw를 이용해 호출부(Repository)로 에러를 전달)

여기서의 문제는 굳이 Repository에서 throw를 잡아내야하는가? 정도일 것 같군
계속 생각이 왔다갔다 하는 중이네만
뭐 지금 시점에서 드는 생각은 이러하네
1. data layer에서 throw를 모두 잡아서 유형만 전달.
2. domain, ui에서는 data 관련 Exception이 추가적으로 생기면 안된다. 그것은 코드의 오류
3. Repository 구현체는 data layer
4. 그러면 여기까지는 throw 잡아내도 되지 않나? 

나의 의견이 괜한 혼란을 부를까 조금 걱정이 되지만 나의 현재 생각은 이러하다네

From. 당신의 친구 Skipancho (@Skipancho)
