### PR TITLE
[FEATURE] HistoryRepository 테스트 코드 작성 및 HistoryDataSource Flow 예외처리 방식 변경

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSource.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSource.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 
 interface HistoryDataSource {
-    fun getItems(): Flow<List<HistoryDto>>
-    fun getPreviewItems(): Flow<List<HistoryDto>>
+    fun getItems(): Flow<Result<List<HistoryDto>>>
+    fun getPreviewItems(): Flow<Result<List<HistoryDto>>>
     suspend fun insertItem(hash: String, name: String): Result<Unit>
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import java.util.*
 import javax.inject.Inject
@@ -16,17 +17,17 @@ class HistoryDataSourceImpl @Inject constructor(
     private val historyDao: HistoryDao,
     private val coroutineDispatcher: CoroutineDispatcher
 ) : HistoryDataSource {
-    override fun getItems(): Flow<List<HistoryDto>> =
+    override fun getItems(): Flow<Result<List<HistoryDto>>> =
         historyDao.getItems()
-            .catch { exception ->
-                throw exception.toErrorEntity()
-            }.flowOn(coroutineDispatcher)
+            .map { Result.success(it) }
+            .catch { exception -> emit(Result.failure(exception.toErrorEntity())) }
+            .flowOn(coroutineDispatcher)
 
-    override fun getPreviewItems(): Flow<List<HistoryDto>> =
+    override fun getPreviewItems(): Flow<Result<List<HistoryDto>>> =
         historyDao.getPreviewItems()
-            .catch { exception ->
-                throw exception.toErrorEntity()
-            }.flowOn(coroutineDispatcher)
+            .map { Result.success(it) }
+            .catch { exception -> emit(Result.failure(exception.toErrorEntity())) }
+            .flowOn(coroutineDispatcher)
 
     override suspend fun insertItem(hash: String, name: String): Result<Unit> {
         return withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
@@ -24,7 +24,7 @@ class HistoryRepositoryImpl @Inject constructor(
             if (previewMode) historyDataSource.getPreviewItems() else historyDataSource.getItems(),
             cartDataSource.getItems()
         ) { historyDtoList, cartDtoList ->
-            Pair(historyDtoList, cartDtoList.getOrThrow())
+            Pair(historyDtoList.getOrThrow(), cartDtoList.getOrThrow())
         }.map { pair ->
             val historyDtoList = pair.first
             val cartDtoList = pair.second

--- a/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImplTest.kt
@@ -54,8 +54,8 @@ class HistoryDataSourceImplTest {
 
     @Test
     fun getItems() = runTest {
-        val expected = historyDao.historyDtos
-        var actual: List<HistoryDto>? = null
+        val expected = Result.success(historyDao.historyDtos)
+        var actual: Result<List<HistoryDto>>? = null
         val collectJob = launch(UnconfinedTestDispatcher()) {
             historyDataSource.getItems().collect { actual = it }
         }
@@ -78,8 +78,8 @@ class HistoryDataSourceImplTest {
 
     @Test
     fun getPreviewItems() = runTest {
-        val expected = historyDao.historyDtos.take(7)
-        var actual: List<HistoryDto>? = null
+        val expected = Result.success(historyDao.historyDtos.take(7))
+        var actual: Result<List<HistoryDto>>? = null
         val collectJob = launch(UnconfinedTestDispatcher()) {
             historyDataSource.getPreviewItems().collect { actual = it }
         }
@@ -92,9 +92,7 @@ class HistoryDataSourceImplTest {
         val expected = Result.failure<List<HistoryDto>>(ErrorEntity.RetryableError)
         var actual: Result<List<HistoryDto>>? = null
         val collectJob = launch(UnconfinedTestDispatcher()) {
-            historyDataSourceWithError.getPreviewItems()
-                .catch { actual = Result.failure(it) }
-                .collect {}
+            historyDataSourceWithError.getPreviewItems().collect { actual = it }
         }
         assertEquals(expected, actual)
         collectJob.cancel()

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImplTest.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImplTest.kt
@@ -1,0 +1,127 @@
+package co.kr.woowahan_banchan.data.repository
+
+import co.kr.woowahan_banchan.data.model.local.CartDto
+import co.kr.woowahan_banchan.data.model.local.HistoryDto
+import co.kr.woowahan_banchan.data.model.remote.response.DetailDataResponse
+import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
+import co.kr.woowahan_banchan.data.repository.fakedatasource.*
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
+import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class HistoryRepositoryImplTest {
+    private val historyDto1 = HistoryDto("HF778", 1661068772834, "소갈비찜")
+
+    //    private val historyDto2 = HistoryDto("H1AA9", 1661073362608, "초계국수_쿠킹박스")
+    private val cartDto1 = CartDto("HF778", 2, true, 1661172787438, "소갈비찜")
+
+    //    private val cartDto2 = CartDto("H1AA9", 1, true, 1661245549658, "초계국수_쿠킹박스")
+    private val detailResponse1 = DetailResponse(
+        hash = "HF778",
+        data = DetailDataResponse(
+            topImageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+            thumbnailUrls = listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_S.jpg"
+            ),
+            productDescription = "촉촉하게 밴 양념이 일품",
+            point = "260원",
+            deliveryInfo = "서울 경기 새벽 배송 / 전국 택배 배송",
+            deliveryFee = "2,500원 (40,000원 이상 구매 시 무료)",
+            prices = listOf("28,900원", "26,010원"),
+            detailSection = listOf(
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D1.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_D2.jpg",
+                "http://public.codesquad.kr/jk/storeapp/data/pakage_regular.jpg"
+            )
+        )
+    )
+
+    private lateinit var historyDataSource: FakeHistoryDataSource
+    private lateinit var cartDataSource: FakeCartDataSource
+    private lateinit var detailDataSource: FakeDetailDataSource
+    private lateinit var historyRepository: HistoryRepositoryImpl
+    private lateinit var historyDataSourceWithError: FakeHistoryDataSourceWithError
+    private lateinit var cartDataSourceWithError: FakeCartDataSourceWithError
+    private lateinit var detailDataSourceWithError: FakeDetailDataSourceWithError
+    private lateinit var historyRepositoryWithError: HistoryRepositoryImpl
+    private val coroutineDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        historyDataSource = FakeHistoryDataSource(listOf(historyDto1))
+        cartDataSource = FakeCartDataSource(mutableListOf(cartDto1))
+        detailDataSource = FakeDetailDataSource(detailResponse1)
+        historyRepository = HistoryRepositoryImpl(
+            historyDataSource,
+            cartDataSource,
+            detailDataSource,
+            coroutineDispatcher
+        )
+        historyDataSourceWithError = FakeHistoryDataSourceWithError()
+        cartDataSourceWithError = FakeCartDataSourceWithError()
+        detailDataSourceWithError = FakeDetailDataSourceWithError()
+        historyRepositoryWithError = HistoryRepositoryImpl(
+            historyDataSourceWithError,
+            cartDataSourceWithError,
+            detailDataSourceWithError,
+            coroutineDispatcher
+        )
+    }
+
+    @Test
+    fun addToHistory() = runTest {
+        val expected = Result.success(Unit)
+        val actual = historyRepository.addToHistory("HASH1", "NAME_OF_PRODUCT")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun addToHistoryWithError() = runTest {
+        val expected = Result.failure<Unit>(ErrorEntity.UnknownError)
+        val actual = historyRepositoryWithError.addToHistory("HASH1", "NAME_OF_PRODUCT")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getHistories() = runTest(coroutineDispatcher) {
+        val expected = Result.success(
+            listOf(
+                HistoryItem(
+                    detailHash = "HF778",
+                    imageUrl = "http://public.codesquad.kr/jk/storeapp/data/main/349_ZIP_P_0024_T.jpg",
+                    title = "소갈비찜",
+                    nPrice = 28900,
+                    sPrice = 26010,
+                    time = 1661068772834,
+                    isAdded = true
+                )
+            )
+        )
+        var actual: Result<List<HistoryItem>>? = null
+        historyRepository.getHistories(true).collect { actual = it }
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getHistoriesWithError() = runTest(coroutineDispatcher) {
+        val expected = Result.failure<List<HistoryItem>>(ErrorEntity.RetryableError)
+        var actual: Result<List<HistoryItem>>? = null
+        historyRepositoryWithError.getHistories(false).collect { actual = it }
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun getHistoriesPreviewWithError() = runTest(coroutineDispatcher) {
+        val expected = Result.failure<List<HistoryItem>>(ErrorEntity.UnknownError)
+        var actual: Result<List<HistoryItem>>? = null
+        historyRepositoryWithError.getHistories(true).collect { actual = it }
+        assertEquals(expected, actual)
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeHistoryDataSource.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeHistoryDataSource.kt
@@ -1,0 +1,22 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
+import co.kr.woowahan_banchan.data.model.local.HistoryDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeHistoryDataSource(initHistoryDtos: List<HistoryDto>): HistoryDataSource {
+    val historyDtos = initHistoryDtos.toMutableList()
+
+    override fun getItems(): Flow<Result<List<HistoryDto>>> {
+        return flow { emit(Result.success(historyDtos)) }
+    }
+
+    override fun getPreviewItems(): Flow<Result<List<HistoryDto>>> {
+        return flow { emit(Result.success(historyDtos)) }
+    }
+
+    override suspend fun insertItem(hash: String, name: String): Result<Unit> {
+        return Result.success(Unit)
+    }
+}

--- a/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeHistoryDataSourceWithError.kt
+++ b/app/src/test/java/co/kr/woowahan_banchan/data/repository/fakedatasource/FakeHistoryDataSourceWithError.kt
@@ -1,0 +1,22 @@
+package co.kr.woowahan_banchan.data.repository.fakedatasource
+
+import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
+import co.kr.woowahan_banchan.data.extension.toErrorEntity
+import co.kr.woowahan_banchan.data.model.local.HistoryDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.io.InterruptedIOException
+
+class FakeHistoryDataSourceWithError: HistoryDataSource {
+    override fun getItems(): Flow<Result<List<HistoryDto>>> {
+        return flow { emit(Result.failure(InterruptedIOException().toErrorEntity())) }
+    }
+
+    override fun getPreviewItems(): Flow<Result<List<HistoryDto>>> {
+        return flow { emit(Result.failure(ClassNotFoundException().toErrorEntity())) }
+    }
+
+    override suspend fun insertItem(hash: String, name: String): Result<Unit> {
+        return Result.failure(IllegalThreadStateException().toErrorEntity())
+    }
+}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #140 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] HistoryRepository 테스트 코드 작성
- [x] HistoryDataSource Flow 예외처리 방식 변경

### 참고사항

이보게 @Skipancho , 이미 내가 슬랙을 통해 공유하긴 했다만, 나 스스로 이해가 되지 않는 점이 있어 이렇게 글을 남기네.
그동안 우리는, runTest {} 로 TestScope을 열고 그 안에서 각종 suspend function을 처리하지 않았나?
그리고 Flow의 경우는 그 TestScope 안에서 launch를 통해 `UnconfinedTestDispatcher`를 사용해 Flow를 collect해왔지.

근데 이상하게도 HistoryRepository에서는 이렇게 했을 때, 문제가 발생하더군.
에러 내용은 아래와 같다네.

> java.lang.IllegalStateException: Detected use of different schedulers. If you need to use several test coroutine dispatchers, create one `TestCoroutineScheduler` and pass it to each of them.

다른 스케줄러를 사용한 것 같고, 여러 코루틴 디스패처를 사용해야 한다면 하나의 `TestCoroutineScheduler`를 만들고 그것을 각각에 전달하라는 이야기로 이해했네.
그런데 그동안의 우리 테스트 코드에서는 왜 이런 문제가 발생하지 않았을까? 왜 갑자기 지금에서야 문제가 발생할까?

나는 이와 관련해 자료를 찾던 중, https://developer.android.com/kotlin/coroutines/test#unconfinedtestdispatcher 를 참고할 수 있었네.
이 링크에 보면, 애초에 runTest에 테스트 디스패처를 전달할 수 있더군. 내가 runTest에 대해 잘 알아보지 않았던 잘못이 있긴 하지만, 테스트 디스패처를 전달함으로써 위의 `IllegalStateException`을 피할 수 있었네.

추가로, 이런 식으로도 가능하더군.

``` kotlin
    @Test
    fun getHistoriesWithError() = runTest(coroutineDispatcher) {
        val expected = Result.failure<List<HistoryItem>>(ErrorEntity.RetryableError)
        var actual: Result<List<HistoryItem>>? = null
        historyRepositoryWithError.getHistories(false).collect { actual = it }
        assertEquals(expected, actual)
    }
```

별도로 launch 빌더를 사용하지 않아도 됐네. 아직도 나는 갈 길이 멀다는 사실에, 또 모르고 쓰고 있었다는 사실에 약간의 현타가 오지만 이에 관해 조금 더 공부해보겠네.
원래 오늘까지는 테스트 코드를 작성하기로 했으니 이 정도의 여유는 가져도 되겠나? 하하하

그럼, 이만.

close #140 