### PR TITLE
[FEATURE] ProductDetailActivity UiStates, UiEvents 적용

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
@@ -20,7 +20,7 @@ import co.kr.woowahan_banchan.presentation.ui.base.BaseActivity
 import co.kr.woowahan_banchan.presentation.ui.cart.CartActivity
 import co.kr.woowahan_banchan.presentation.ui.order.OrderActivity
 import co.kr.woowahan_banchan.presentation.ui.widget.CartAddDialog
-import co.kr.woowahan_banchan.presentation.viewmodel.UiState
+import co.kr.woowahan_banchan.presentation.viewmodel.UiStates
 import co.kr.woowahan_banchan.presentation.viewmodel.productdetail.ProductDetailViewModel
 import co.kr.woowahan_banchan.util.ImageLoader
 import co.kr.woowahan_banchan.util.dpToPx
@@ -33,7 +33,6 @@ import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import timber.log.Timber
 
 @AndroidEntryPoint
 class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
@@ -96,15 +95,14 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
             .flowWithLifecycle(lifecycle)
             .onEach {
                 when (it) {
-                    is UiState.Init -> {
+                    is UiStates.Init -> {
                         showProgressBar()
                     }
-                    is UiState.Success -> {
-                        Timber.tag("dishInfo").i(it.toString())
+                    is UiStates.Success -> {
                         hideProgressBar()
                         showUi(it.data)
                     }
-                    is UiState.Error -> {
+                    is UiStates.Error -> {
                         hideProgressBar()
                         shortToast(it.message)
                         finish()
@@ -116,9 +114,9 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
             .flowWithLifecycle(lifecycle)
             .onEach {
                 binding.tvAmountValue.text = it.toPriceFormat()
-                if (viewModel.dishInfo.value is UiState.Success) {
+                if (viewModel.dishInfo.value is UiStates.Success) {
                     val price =
-                        (viewModel.dishInfo.value as UiState.Success).data.prices.last()
+                        (viewModel.dishInfo.value as UiStates.Success).data.prices.last()
                     showTotalPrice(it, price)
                 }
             }.launchIn(lifecycleScope)

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/productdetail/ProductDetailViewModel.kt
@@ -3,8 +3,9 @@ package co.kr.woowahan_banchan.presentation.viewmodel.productdetail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.kr.woowahan_banchan.domain.entity.detail.DishInfo
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
 import co.kr.woowahan_banchan.domain.usecase.*
-import co.kr.woowahan_banchan.presentation.viewmodel.UiState
+import co.kr.woowahan_banchan.presentation.viewmodel.UiStates
 import co.kr.woowahan_banchan.util.calculateDiffToMinute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -21,22 +22,31 @@ class ProductDetailViewModel @Inject constructor(
     private val getCartItemCountUseCase: GetCartItemCountUseCase,
     private val latestOrderTimeUseCase: LatestOrderTimeUseCase
 ) : ViewModel() {
-    private val _dishInfo = MutableStateFlow<UiState<DishInfo>>(UiState.Init)
-    val dishInfo: StateFlow<UiState<DishInfo>> get() = _dishInfo
+    // State
+    private val _dishInfo = MutableStateFlow<UiStates<DishInfo>>(UiStates.Init)
+    val dishInfo: StateFlow<UiStates<DishInfo>> get() = _dishInfo
     private val _amount = MutableStateFlow<Int>(1)
     val amount: StateFlow<Int> get() = _amount
-    private val _isAddSuccess = MutableSharedFlow<Boolean>()
-    val isAddSuccess: SharedFlow<Boolean> get() = _isAddSuccess
     private val _cartCount = MutableStateFlow(0)
     val cartCount: StateFlow<Int> get() = _cartCount
+
+    // Event
+    private val _isAddSuccess = MutableSharedFlow<Boolean>()
+    val isAddSuccess: SharedFlow<Boolean> get() = _isAddSuccess
     private val _isOrderCompleted = MutableStateFlow<Boolean>(true)
     val isOrderCompleted: StateFlow<Boolean> get() = _isOrderCompleted
 
     fun fetchUiState(hash: String) {
         viewModelScope.launch {
             productDetailUseCase(hash)
-                .onSuccess { _dishInfo.value = UiState.Success(it) }
-                .onFailure { _dishInfo.value = UiState.Error(it.message) }
+                .onSuccess { _dishInfo.value = UiStates.Success(it) }
+                .onFailure {
+                    _dishInfo.value = when (it as ErrorEntity) {
+                        is ErrorEntity.RetryableError -> UiStates.Error("문제가 생겼어요! 다시 시도해보시겠어요?")
+                        is ErrorEntity.ConditionalError -> UiStates.Error("인터넷 연결에 문제가 있어요!")
+                        is ErrorEntity.UnknownError -> UiStates.Error("앗! 문제가 발생했어요!")
+                    }
+                }
         }
     }
 


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #158 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 반찬 정보 상태(`dishInfo`): UiStates로 처리, 실패 시 ErrorEntity 유형별 다른 string으로 Toast 표시
- [x] 장바구니 추가 이벤트(`cartAddEvent`): UiEvents로 처리, 실패 시 ErrorEntity 유형별 다른 ErrorDialog 표시
- [x] 배송 상태(`deliveryState`): UiStates로 처리, 실패 시 ErrorEntity 유형 관계없이 string으로 Toast 표시

close #158 