### PR TITLE
[FEATURE] OrderListFragment UiStates, UiEvents 적용

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/adapter/OrderListAdapter.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/adapter/OrderListAdapter.kt
@@ -27,7 +27,11 @@ class OrderListAdapter(private val itemClick: (OrderHistory) -> Unit) :
                         binding.ivThumbnail.setImageBitmap(it)
                     }
                 }
-                binding.tvTitle.text = this.title
+                binding.tvTitle.text = if (this.count > 1) {
+                    this.title + " 외 ${this.count - 1}개"
+                } else {
+                    this.title
+                }
                 binding.tvPrice.text = this.totalPrice.toPriceFormat() + "원"
                 setDeliveryInfo(time)
             }

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/order/OrderListViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/order/OrderListViewModel.kt
@@ -2,11 +2,15 @@ package co.kr.woowahan_banchan.presentation.viewmodel.order
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.kr.woowahan_banchan.domain.entity.error.ErrorEntity
 import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderHistory
 import co.kr.woowahan_banchan.domain.usecase.OrderListUseCase
-import co.kr.woowahan_banchan.presentation.viewmodel.UiState
+import co.kr.woowahan_banchan.presentation.viewmodel.UiEvents
+import co.kr.woowahan_banchan.presentation.viewmodel.UiStates
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,14 +19,19 @@ import javax.inject.Inject
 class OrderListViewModel @Inject constructor(
     private val orderListUseCase: OrderListUseCase
 ) : ViewModel() {
-    private val _orderHistories = MutableStateFlow<UiState<List<OrderHistory>>>(UiState.Init)
-    val orderHistories: StateFlow<UiState<List<OrderHistory>>> get() = _orderHistories
+    private val _orderHistories = MutableStateFlow<UiStates<List<OrderHistory>>>(UiStates.Init)
+    val orderHistories: StateFlow<UiStates<List<OrderHistory>>> get() = _orderHistories
+    private val _orderHistoriesEvents = MutableSharedFlow<UiEvents<Unit>>()
+    val orderHistoriesEvents: SharedFlow<UiEvents<Unit>> get() = _orderHistoriesEvents
 
     fun fetchOrderHistories() {
         viewModelScope.launch {
             orderListUseCase()
-                .onSuccess { _orderHistories.value = UiState.Success(it) }
-                .onFailure { _orderHistories.value = UiState.Error(it.message) }
+                .onSuccess { _orderHistories.value = UiStates.Success(it) }
+                .onFailure {
+                    _orderHistories.value = UiStates.Error(it.message)
+                    _orderHistoriesEvents.emit(UiEvents.Error(it as ErrorEntity))
+                }
         }
     }
 }


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #159 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 주문내역(`orderHistories`): UiStates로 처리, 실패 시 ProgressBar 숨김 이외 별도의 처리 하지 않음
- [x] 주문내역 가져오기 이벤트(`orderHistoriesEvent`): UiEvents로 처리, 실패 시 유형별 다른 ErrorDialog 표시
- [x] ViewModel의 fetch 메서드에서 UseCase의 return이 Result.failure인 경우 `orderHistories`, `orderHistoriesEvent` 둘 다에 값 할당

close #159 