### PR TITLE
[FIX] 카트 개수가 10개 이상이 되면 9+가 되도록 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/MainActivity.kt
@@ -53,7 +53,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
             bd.backgroundColor = resources.getColor(R.color.grayscale_000000, theme)
             bd.horizontalOffset = 5.dpToPx()
             bd.verticalOffset = 5.dpToPx()
-            bd.maxCharacterCount = 3
+            bd.maxCharacterCount = 2
         }
     }
 

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/productdetail/ProductDetailActivity.kt
@@ -52,7 +52,7 @@ class ProductDetailActivity : BaseActivity<ActivityProductDetailBinding>() {
             bd.backgroundColor = resources.getColor(R.color.grayscale_000000, theme)
             bd.horizontalOffset = 5.dpToPx()
             bd.verticalOffset = 5.dpToPx()
-            bd.maxCharacterCount = 3
+            bd.maxCharacterCount = 2
         }
     }
 


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #199 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 카트 개수가 10개 이상이 되면 9+가 되도록 수정

요구사항이 10개 이상일 경우 10+로 나타내라고 하지만 왜 10+를 해야하는지 잘 모르겠네, 이렇게 바꾸는 이유는 숫자의 텍스트 길이를 더이상 늘리지 않는 것에 있다고 생각을 하네, 그렇지만 10+는 99보다 길이가 더 길지 않나? 그렇다면 10+가 99로 텍스트를 치는 것 보다 좋은 것이 전혀 없다고 생각을 하네 그렇기 때문에 9+가 되도록 수정했다네

close #199 