### PR TITLE
[FIX] 장바구니 화면에서 최근 본 화면으로 넘어가 장바구니를 추가하게 되면 주문이 중복되는 오류 수정

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/cart/CartViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/cart/CartViewModel.kt
@@ -59,6 +59,8 @@ class CartViewModel @Inject constructor(
                 .collect { result ->
                     result.onSuccess {
                         _cartItems.value = UiState.Success(it)
+
+                        originalCart.clear()
                         it.forEach { item ->
                             originalCart.add(item.copy())
                         }


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #200 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 장바구니 화면에서 최근 본 화면으로 넘어가 장바구니를 추가하게 되면 주문이 중복되는 오류 수정

close #200

이 부분은 음 CartFragment에서 HistoryFragment로 이동할 시 CartFragment의 onDestroy가 호출되지 않아 viewModel이 계속 살아있다는 것을 간과했네, 그래서 계속 originalCart에 갱신된 장바구니 목록이 추가되고 있었던거야... OrderUseCase에서는 originalCart를 기준으로 주문과 갱신을 하기 때문에 중복되어 주문이 들어가는 현상이 일어났던 것으로 추측하네 이 문제는 originalCart가 갱신될때 해당 리스트를 clear하는 것으로 해결했다네