### PR TITLE
[FIX] 네트워크 연결 해제 상태에서 에러 다이얼로그가 여러 번 표시되는 오류

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/best/BestFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/best/BestFragment.kt
@@ -22,6 +22,7 @@ import co.kr.woowahan_banchan.util.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 @AndroidEntryPoint
 class BestFragment : BaseFragment<FragmentBestBinding>() {
@@ -42,6 +43,16 @@ class BestFragment : BaseFragment<FragmentBestBinding>() {
         super.onViewCreated(view, savedInstanceState)
         initView()
         observeData()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.getBests()
+    }
+
+    override fun onPause() {
+        viewModel.cancelCollectJob()
+        super.onPause()
     }
 
     private fun initView() {
@@ -69,6 +80,7 @@ class BestFragment : BaseFragment<FragmentBestBinding>() {
             .flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
                 if (it is UiEvent.Error) {
+                    Timber.e(it.error)
                     showErrorDialog(it)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/maindish/MainDishFragment.kt
@@ -27,6 +27,7 @@ import co.kr.woowahan_banchan.util.dpToPx
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainDishFragment : BaseFragment<FragmentMainDishBinding>() {
@@ -59,6 +60,16 @@ class MainDishFragment : BaseFragment<FragmentMainDishBinding>() {
         initView()
         observeData()
         setListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.getDishes()
+    }
+
+    override fun onPause() {
+        viewModel.cancelCollectJob()
+        super.onPause()
     }
 
     private fun initView() {
@@ -95,6 +106,7 @@ class MainDishFragment : BaseFragment<FragmentMainDishBinding>() {
             .flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .onEach {
                 if (it is UiEvent.Error) {
+                    Timber.e(it.error)
                     showErrorDialog(it)
                 }
             }.launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/otherdish/OtherDishFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/main/otherdish/OtherDishFragment.kt
@@ -63,6 +63,16 @@ class OtherDishFragment : BaseFragment<FragmentOtherDishBinding>() {
         initData()
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.getDishes(dishType)
+    }
+
+    override fun onPause() {
+        viewModel.cancelCollectJob()
+        super.onPause()
+    }
+
     private fun initData() {
         when (dishType) {
             DishType.SOUP.name -> {

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/main/BestViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/main/BestViewModel.kt
@@ -30,21 +30,28 @@ class BestViewModel @Inject constructor(
         getBests()
     }
 
-    private fun getBests() {
-        collectJob = viewModelScope.launch {
-            getBestsUseCase()
-                .collect { result ->
-                    result.onSuccess { _bestItems.value = UiState.Success(it) }
-                        .onFailure {
-                            _bestItems.value = UiState.Error(it.message)
-                            _bestItemsEvent.emit(UiEvent.Error(it as ErrorEntity))
-                        }
-                }
+    fun getBests() {
+        if (collectJob == null) {
+            collectJob = viewModelScope.launch {
+                getBestsUseCase()
+                    .collect { result ->
+                        result.onSuccess { _bestItems.value = UiState.Success(it) }
+                            .onFailure {
+                                _bestItems.value = UiState.Error(it.message)
+                                _bestItemsEvent.emit(UiEvent.Error(it as ErrorEntity))
+                            }
+                    }
+            }
         }
     }
 
-    fun reFetchBests() {
+    fun cancelCollectJob() {
         collectJob?.cancel()
+        collectJob = null
+    }
+
+    fun reFetchBests() {
+        cancelCollectJob()
         getBests()
     }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/main/MainDishViewModel.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/viewmodel/main/MainDishViewModel.kt
@@ -38,19 +38,26 @@ class MainDishViewModel @Inject constructor(
         getDishes()
     }
 
-    private fun getDishes() {
-        collectJob = viewModelScope.launch {
-            getDishesUseCase(Source.MAIN)
-                .collect { result ->
-                    result.onSuccess {
-                        defaultMainDishes = it
-                        _mainDishes.value = UiState.Success(it)
-                    }.onFailure {
-                        _mainDishes.value = UiState.Error(it.message)
-                        _mainDishesEvent.emit(UiEvent.Error(it as ErrorEntity))
+    fun getDishes() {
+        if (collectJob == null) {
+            collectJob = viewModelScope.launch {
+                getDishesUseCase(Source.MAIN)
+                    .collect { result ->
+                        result.onSuccess {
+                            defaultMainDishes = it
+                            _mainDishes.value = UiState.Success(it)
+                        }.onFailure {
+                            _mainDishes.value = UiState.Error(it.message)
+                            _mainDishesEvent.emit(UiEvent.Error(it as ErrorEntity))
+                        }
                     }
-                }
+            }
         }
+    }
+
+    fun cancelCollectJob() {
+        collectJob?.cancel()
+        collectJob = null
     }
 
     fun setSortedDishes(sortType: Int) {
@@ -73,7 +80,7 @@ class MainDishViewModel @Inject constructor(
     }
 
     fun reFetchDishes() {
-        collectJob?.cancel()
+        cancelCollectJob()
         getDishes()
     }
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/util/ImageLoader.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/util/ImageLoader.kt
@@ -46,7 +46,7 @@ class ImageLoader(
                 urlConnection = getUrlConnection(url)
                 val stream = urlConnection?.inputStream
                 BitmapFactory.decodeStream(stream)
-            }.onSuccess {
+            }.mapCatching {
                 cache[url] = it
                 withContext(Dispatchers.Main) { setImage(it) }
             }.onFailure {


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #206 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
원인을 파악했네. 왜 에러 다이얼로그가 여러 번 뜨는지 말일세.
ViewPager2의 경우 Fragment가 onDestroy되지 않는 사실을 아는가? 여기서 바로 문제가 시작되는 것이었어.
우리는 Cart 데이터를 Flow로 collect하고 있는데, Fragment가 onStop조차 들어가지 않기 때문에 ViewModel이 죽지 않았고, 그래서 계속 collect가 되면서 네트워크 요청을 레포지토리에서 하기 때문에 에러가 4번 났다고 파악하는 것이었어.

그래서 onPause에서 ViewModel의 collect를 취소하도록 했네. 그리고 onResume에서 다시 collect를 하도록 처리했네. 우리의 `빨대` 비유를 생각하면서 말이야.

close #206 