### PR TITLE
[FIX] 장바구니 화면에서 주문 후 화면 회전 시 화면 유지되지 않는 오류

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/CartActivity.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/CartActivity.kt
@@ -9,6 +9,7 @@ import co.kr.woowahan_banchan.R
 import co.kr.woowahan_banchan.databinding.ActivityCartBinding
 import co.kr.woowahan_banchan.presentation.ui.base.BaseActivity
 import co.kr.woowahan_banchan.presentation.ui.cart.history.HistoryFragment
+import co.kr.woowahan_banchan.presentation.ui.order.orderdetail.OrderDetailFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -18,26 +19,41 @@ class CartActivity : BaseActivity<ActivityCartBinding>() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        initView(savedInstanceState?.getInt("backStackCount"))
+        initView(
+            savedInstanceState?.getInt("backStackCount"),
+            savedInstanceState?.getBoolean("orderDetail") ?: false
+        )
     }
 
-    private fun initView(backStackCount : Int?) {
+    private fun initView(backStackCount: Int?, orderDetail: Boolean) {
         initToolbar()
-        while (supportFragmentManager.backStackEntryCount > 0){
+        while (supportFragmentManager.backStackEntryCount > 0) {
             supportFragmentManager.popBackStackImmediate()
         }
         supportFragmentManager.commit {
-            replace(R.id.fcv_cart,CartFragment())
-            if (backStackCount != 0 && backStackCount != null){
-                replace(R.id.fcv_cart,HistoryFragment())
-                addToBackStack("cart")
+            if (orderDetail) {
+                replace(
+                    R.id.fcv_cart,
+                    OrderDetailFragment.newInstance(OrderDetailFragment.selectedOrderId!!),
+                    OrderDetailFragment::class.java.simpleName
+                )
+            } else {
+                replace(R.id.fcv_cart, CartFragment())
+                if (backStackCount != 0 && backStackCount != null) {
+                    replace(R.id.fcv_cart, HistoryFragment())
+                    addToBackStack("cart")
+                }
             }
         }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putInt("backStackCount",supportFragmentManager.backStackEntryCount)
+        outState.putInt("backStackCount", supportFragmentManager.backStackEntryCount)
+        outState.putBoolean(
+            "orderDetail",
+            supportFragmentManager.findFragmentByTag(OrderDetailFragment::class.java.simpleName) != null
+        )
     }
 
     private fun initToolbar() {
@@ -47,7 +63,7 @@ class CartActivity : BaseActivity<ActivityCartBinding>() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home){
+        if (item.itemId == android.R.id.home) {
             if (supportFragmentManager.backStackEntryCount == 0) {
                 finish()
             } else {

--- a/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/CartFragment.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/presentation/ui/cart/CartFragment.kt
@@ -150,7 +150,11 @@ class CartFragment : BaseFragment<FragmentCartBinding>() {
                         )
 
                         parentFragmentManager.commit {
-                            replace(R.id.fcv_cart, OrderDetailFragment.newInstance(it.data))
+                            replace(
+                                R.id.fcv_cart,
+                                OrderDetailFragment.newInstance(it.data),
+                                OrderDetailFragment::class.java.simpleName
+                            )
                         }
                     }
                     is UiState.Error -> {}


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #203 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] 장바구니 화면에서 주문 후 화면 회전 시 화면 유지되지 않는 오류 해결

### 확인사항
Fragment BackStackCount만으론 문제를 해결할 수 없어서, 난 이렇게 처리했다네.
OrderDetailFragment로 replace할 때, 클래스명으로 태그를 붙이는거지. 그리고 이 태그로 Fragment가 존재하는지 여부를 `findFragmentByTag`로 체크해서, 이 값을 `onSaveInstanceState`의 `outState`에 putBoolean으로 전달하는 것이네.
생각보다 쉽게 해결한 듯 하구만. 하하하

close #203 