### PR TITLE
[REFACTOR] Hilt @Binds, @Provides 리팩토링

### DIFF
--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/cart/CartDataSourceImpl.kt
@@ -4,6 +4,7 @@ import co.kr.woowahan_banchan.data.database.dao.CartDao
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.extension.toErrorEntity
 import co.kr.woowahan_banchan.data.model.local.CartDto
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -14,7 +15,7 @@ import javax.inject.Inject
 
 class CartDataSourceImpl @Inject constructor(
     private val cartDao: CartDao,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : CartDataSource {
     override fun getItems(): Flow<Result<List<CartDto>>> =
         cartDao.getItems()

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/history/HistoryDataSourceImpl.kt
@@ -4,6 +4,7 @@ import co.kr.woowahan_banchan.data.database.dao.HistoryDao
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.extension.toErrorEntity
 import co.kr.woowahan_banchan.data.model.local.HistoryDto
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -15,7 +16,7 @@ import javax.inject.Inject
 
 class HistoryDataSourceImpl @Inject constructor(
     private val historyDao: HistoryDao,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : HistoryDataSource {
     override fun getItems(): Flow<Result<List<HistoryDto>>> =
         historyDao.getItems()

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/order/OrderDataSourceImpl.kt
@@ -4,6 +4,7 @@ import co.kr.woowahan_banchan.data.database.dao.OrderDao
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.extension.toErrorEntity
 import co.kr.woowahan_banchan.data.model.local.OrderDto
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
@@ -11,7 +12,7 @@ import javax.inject.Inject
 
 class OrderDataSourceImpl @Inject constructor(
     private val orderDao: OrderDao,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : OrderDataSource {
     override suspend fun getItems(): Result<List<OrderDto>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/local/orderitem/OrderItemDataSourceImpl.kt
@@ -3,13 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.local.orderitem
 import co.kr.woowahan_banchan.data.database.dao.OrderItemDao
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.local.OrderItemDto
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class OrderItemDataSourceImpl @Inject constructor(
     private val orderItemDao: OrderItemDao,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : OrderItemDataSource {
     override suspend fun getItems(orderId: Long): Result<List<OrderItemDto>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/best/BestDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/best/BestDataSourceImpl.kt
@@ -3,12 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.remote.best
 import co.kr.woowahan_banchan.data.api.BestService
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.BestResponse
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class BestDataSourceImpl(
+class BestDataSourceImpl @Inject constructor(
     private val service: BestService,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : BestDataSource {
     override suspend fun getBests(): Result<List<BestResponse>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/detail/DetailDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/detail/DetailDataSourceImpl.kt
@@ -3,12 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.remote.detail
 import co.kr.woowahan_banchan.data.api.DetailService
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DetailResponse
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class DetailDataSourceImpl(
+class DetailDataSourceImpl @Inject constructor(
     private val service: DetailService,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : DetailDataSource {
     override suspend fun getDetail(hash: String): Result<DetailResponse> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/maindish/MainDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/maindish/MainDishDataSourceImpl.kt
@@ -3,12 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.remote.maindish
 import co.kr.woowahan_banchan.data.api.MainDishService
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class MainDishDataSourceImpl(
+class MainDishDataSourceImpl @Inject constructor(
     private val service: MainDishService,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : MainDishDataSource {
     override suspend fun getMainDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/sidedish/SideDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/sidedish/SideDishDataSourceImpl.kt
@@ -3,12 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.remote.sidedish
 import co.kr.woowahan_banchan.data.api.SideDishService
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class SideDishDataSourceImpl(
+class SideDishDataSourceImpl @Inject constructor(
     private val service: SideDishService,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : SideDishDataSource {
     override suspend fun getSideDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/soupdish/SoupDishDataSourceImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/datasource/remote/soupdish/SoupDishDataSourceImpl.kt
@@ -3,12 +3,14 @@ package co.kr.woowahan_banchan.data.datasource.remote.soupdish
 import co.kr.woowahan_banchan.data.api.SoupDishService
 import co.kr.woowahan_banchan.data.extension.runCatchingErrorEntity
 import co.kr.woowahan_banchan.data.model.remote.response.DishResponse
+import co.kr.woowahan_banchan.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class SoupDishDataSourceImpl(
+class SoupDishDataSourceImpl @Inject constructor(
     private val service: SoupDishService,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @IoDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : SoupDishDataSource {
     override suspend fun getSoupDishes(): Result<List<DishResponse>> =
         withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/CartRepositoryImpl.kt
@@ -3,6 +3,7 @@ package co.kr.woowahan_banchan.data.repository
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
 import co.kr.woowahan_banchan.data.model.local.CartDto
+import co.kr.woowahan_banchan.di.DefaultDispatcher
 import co.kr.woowahan_banchan.domain.entity.cart.CartItem
 import co.kr.woowahan_banchan.domain.repository.CartRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -15,7 +16,7 @@ import javax.inject.Inject
 class CartRepositoryImpl @Inject constructor(
     private val cartDataSource: CartDataSource,
     private val detailDataSource: DetailDataSource,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @DefaultDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : CartRepository {
     override suspend fun addToCart(hash: String, amount: Int, name: String): Result<Unit> {
         val originalAmount = cartDataSource.getAmount(hash).getOrDefault(0)

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/DishRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/DishRepositoryImpl.kt
@@ -5,6 +5,7 @@ import co.kr.woowahan_banchan.data.datasource.remote.best.BestDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.maindish.MainDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.sidedish.SideDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.soupdish.SoupDishDataSource
+import co.kr.woowahan_banchan.di.DefaultDispatcher
 import co.kr.woowahan_banchan.domain.entity.dish.BestItem
 import co.kr.woowahan_banchan.domain.entity.dish.Dish
 import co.kr.woowahan_banchan.domain.repository.DishRepository
@@ -22,7 +23,7 @@ class DishRepositoryImpl @Inject constructor(
     private val mainDishDataSource: MainDishDataSource,
     private val sideDishDataSource: SideDishDataSource,
     private val soupDishDataSource: SoupDishDataSource,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @DefaultDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : DishRepository {
     override fun getBestDishes(): Flow<Result<List<BestItem>>> {
         return cartDataSource.getItems().map { result ->

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/HistoryRepositoryImpl.kt
@@ -3,6 +3,7 @@ package co.kr.woowahan_banchan.data.repository
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
+import co.kr.woowahan_banchan.di.DefaultDispatcher
 import co.kr.woowahan_banchan.domain.entity.history.HistoryItem
 import co.kr.woowahan_banchan.domain.repository.HistoryRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -13,7 +14,7 @@ class HistoryRepositoryImpl @Inject constructor(
     private val historyDataSource: HistoryDataSource,
     private val cartDataSource: CartDataSource,
     private val detailDataSource: DetailDataSource,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @DefaultDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : HistoryRepository {
     override suspend fun addToHistory(hash: String, name: String): Result<Unit> {
         return historyDataSource.insertItem(hash, name)

--- a/app/src/main/java/co/kr/woowahan_banchan/data/repository/OrderHistoryRepositoryImpl.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/data/repository/OrderHistoryRepositoryImpl.kt
@@ -4,6 +4,7 @@ import co.kr.woowahan_banchan.data.datasource.local.order.OrderDataSource
 import co.kr.woowahan_banchan.data.datasource.local.orderitem.OrderItemDataSource
 import co.kr.woowahan_banchan.data.model.local.OrderDto
 import co.kr.woowahan_banchan.data.model.local.OrderItemDto
+import co.kr.woowahan_banchan.di.DefaultDispatcher
 import co.kr.woowahan_banchan.domain.entity.cart.CartItem
 import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderHistory
 import co.kr.woowahan_banchan.domain.entity.orderhistory.OrderItem
@@ -17,7 +18,7 @@ import javax.inject.Inject
 class OrderHistoryRepositoryImpl @Inject constructor(
     private val orderDataSource: OrderDataSource,
     private val orderItemDataSource: OrderItemDataSource,
-    private val coroutineDispatcher: CoroutineDispatcher
+    @DefaultDispatcher private val coroutineDispatcher: CoroutineDispatcher
 ) : OrderHistoryRepository {
     override suspend fun getOrderHistories(): Result<List<OrderHistory>> {
         return withContext(coroutineDispatcher) {

--- a/app/src/main/java/co/kr/woowahan_banchan/di/ApiModule.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/di/ApiModule.kt
@@ -17,71 +17,61 @@ import javax.inject.Singleton
 object ApiModule {
     @Provides
     @Singleton
-    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
-        return HttpLoggingInterceptor().apply {
+    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor =
+        HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
-    }
 
     @Provides
     @Singleton
     fun provideHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor
-    ): OkHttpClient {
-        return OkHttpClient.Builder().apply {
-            addInterceptor(httpLoggingInterceptor)
-        }.build()
-    }
+    ): OkHttpClient = OkHttpClient.Builder().apply {
+        addInterceptor(httpLoggingInterceptor)
+    }.build()
+
+    @Provides
+    @Singleton
+    fun provideGsonConverterFactory(): GsonConverterFactory = GsonConverterFactory.create()
 
     @Provides
     @Singleton
     fun provideRetrofit(
-        httpClient: OkHttpClient
-    ): Retrofit {
-        return Retrofit.Builder()
-            .baseUrl(BuildConfig.apiUrl)
-            .addConverterFactory(GsonConverterFactory.create())
-            .client(httpClient)
-            .build()
-    }
+        httpClient: OkHttpClient,
+        gsonConverterFactory: GsonConverterFactory
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.apiUrl)
+        .addConverterFactory(gsonConverterFactory)
+        .client(httpClient)
+        .build()
 
     @Provides
     @Singleton
     fun provideBestService(
         retrofit: Retrofit
-    ): BestService {
-        return retrofit.create(BestService::class.java)
-    }
+    ): BestService = retrofit.create(BestService::class.java)
 
     @Provides
     @Singleton
     fun provideMainDishService(
         retrofit: Retrofit
-    ): MainDishService {
-        return retrofit.create(MainDishService::class.java)
-    }
+    ): MainDishService = retrofit.create(MainDishService::class.java)
 
     @Provides
     @Singleton
     fun provideSideDishService(
         retrofit: Retrofit
-    ): SideDishService {
-        return retrofit.create(SideDishService::class.java)
-    }
+    ): SideDishService = retrofit.create(SideDishService::class.java)
 
     @Provides
     @Singleton
     fun provideSoupDishService(
         retrofit: Retrofit
-    ): SoupDishService {
-        return retrofit.create(SoupDishService::class.java)
-    }
+    ): SoupDishService = retrofit.create(SoupDishService::class.java)
 
     @Provides
     @Singleton
     fun provideDetailService(
         retrofit: Retrofit
-    ): DetailService {
-        return retrofit.create(DetailService::class.java)
-    }
+    ): DetailService = retrofit.create(DetailService::class.java)
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/di/DataSourceModule.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/di/DataSourceModule.kt
@@ -1,10 +1,5 @@
 package co.kr.woowahan_banchan.di
 
-import co.kr.woowahan_banchan.data.api.*
-import co.kr.woowahan_banchan.data.database.dao.CartDao
-import co.kr.woowahan_banchan.data.database.dao.HistoryDao
-import co.kr.woowahan_banchan.data.database.dao.OrderDao
-import co.kr.woowahan_banchan.data.database.dao.OrderItemDao
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
 import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSourceImpl
 import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
@@ -23,79 +18,69 @@ import co.kr.woowahan_banchan.data.datasource.remote.sidedish.SideDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.sidedish.SideDishDataSourceImpl
 import co.kr.woowahan_banchan.data.datasource.remote.soupdish.SoupDishDataSource
 import co.kr.woowahan_banchan.data.datasource.remote.soupdish.SoupDishDataSourceImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DataSourceModule {
-    @Provides
+abstract class DataSourceModule {
+    @Binds
     @Singleton
-    fun provideCartDataSource(
-        cartDao: CartDao,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): CartDataSource = CartDataSourceImpl(cartDao, coroutineDispatcher)
+    abstract fun provideCartDataSource(
+        cartDataSourceImpl: CartDataSourceImpl
+    ): CartDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideHistoryDataSource(
-        historyDao: HistoryDao,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): HistoryDataSource = HistoryDataSourceImpl(historyDao, coroutineDispatcher)
+    abstract fun provideHistoryDataSource(
+        historyDataSourceImpl: HistoryDataSourceImpl
+    ): HistoryDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideOrderDataSource(
-        orderDao: OrderDao,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): OrderDataSource = OrderDataSourceImpl(orderDao, coroutineDispatcher)
+    abstract fun provideOrderDataSource(
+        orderDataSourceImpl: OrderDataSourceImpl
+    ): OrderDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideOrderItemDataSource(
-        orderItemDao: OrderItemDao,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): OrderItemDataSource = OrderItemDataSourceImpl(orderItemDao, coroutineDispatcher)
+    abstract fun provideOrderItemDataSource(
+        orderItemDataSourceImpl: OrderItemDataSourceImpl
+    ): OrderItemDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideBestDataSource(
-        service: BestService,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): BestDataSource = BestDataSourceImpl(service, coroutineDispatcher)
+    abstract fun provideBestDataSource(
+        bestDataSourceImpl: BestDataSourceImpl
+    ): BestDataSource
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideDetailDataSource(
-        service: DetailService,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): DetailDataSource = DetailDataSourceImpl(service, coroutineDispatcher)
+    abstract fun provideDetailDataSource(
+        detailDataSourceImpl: DetailDataSourceImpl
+    ): DetailDataSource
 
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideMainDishDataSource(
-        service: MainDishService,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): MainDishDataSource = MainDishDataSourceImpl(service, coroutineDispatcher)
+    abstract fun provideMainDishDataSource(
+        mainDishDataSourceImpl: MainDishDataSourceImpl
+    ): MainDishDataSource
 
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideSideDishDataSource(
-        service: SideDishService,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): SideDishDataSource = SideDishDataSourceImpl(service, coroutineDispatcher)
+    abstract fun provideSideDishDataSource(
+        sideDishDataSourceImpl: SideDishDataSourceImpl
+    ): SideDishDataSource
 
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideSoupDishDataSource(
-        service: SoupDishService,
-        @IoDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): SoupDishDataSource = SoupDishDataSourceImpl(service, coroutineDispatcher)
+    abstract fun provideSoupDishDataSource(
+        soupDishDataSourceImpl: SoupDishDataSourceImpl
+    ): SoupDishDataSource
 }

--- a/app/src/main/java/co/kr/woowahan_banchan/di/RepositoryModule.kt
+++ b/app/src/main/java/co/kr/woowahan_banchan/di/RepositoryModule.kt
@@ -1,79 +1,43 @@
 package co.kr.woowahan_banchan.di
 
-import co.kr.woowahan_banchan.data.datasource.local.cart.CartDataSource
-import co.kr.woowahan_banchan.data.datasource.local.history.HistoryDataSource
-import co.kr.woowahan_banchan.data.datasource.local.order.OrderDataSource
-import co.kr.woowahan_banchan.data.datasource.local.orderitem.OrderItemDataSource
-import co.kr.woowahan_banchan.data.datasource.remote.best.BestDataSource
-import co.kr.woowahan_banchan.data.datasource.remote.detail.DetailDataSource
-import co.kr.woowahan_banchan.data.datasource.remote.maindish.MainDishDataSource
-import co.kr.woowahan_banchan.data.datasource.remote.sidedish.SideDishDataSource
-import co.kr.woowahan_banchan.data.datasource.remote.soupdish.SoupDishDataSource
 import co.kr.woowahan_banchan.data.repository.*
 import co.kr.woowahan_banchan.domain.repository.*
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RepositoryModule {
-    @Provides
+abstract class RepositoryModule {
+    @Binds
     @Singleton
-    fun provideDishRepository(
-        cartDataSource: CartDataSource,
-        bestDataSource: BestDataSource,
-        mainDishDataSource: MainDishDataSource,
-        sideDishDataSource: SideDishDataSource,
-        soupDishDataSource: SoupDishDataSource,
-        @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): DishRepository = DishRepositoryImpl(
-        cartDataSource,
-        bestDataSource,
-        mainDishDataSource,
-        sideDishDataSource,
-        soupDishDataSource,
-        coroutineDispatcher
-    )
+    abstract fun provideDishRepository(
+        dishRepositoryImpl: DishRepositoryImpl
+    ): DishRepository
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideHistoryRepository(
-        historyDataSource: HistoryDataSource,
-        cartDataSource: CartDataSource,
-        detailDataSource: DetailDataSource,
-        @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): HistoryRepository =
-        HistoryRepositoryImpl(
-            historyDataSource,
-            cartDataSource,
-            detailDataSource,
-            coroutineDispatcher
-        )
+    abstract fun provideHistoryRepository(
+        historyRepositoryImpl: HistoryRepositoryImpl
+    ): HistoryRepository
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideDetailRepository(
-        detailDataSource: DetailDataSource
-    ): DetailRepository = DetailRepositoryImpl(detailDataSource)
+    abstract fun provideDetailRepository(
+        detailRepositoryImpl: DetailRepositoryImpl
+    ): DetailRepository
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideOrderHistoryRepository(
-        orderDataSource: OrderDataSource,
-        orderItemDataSource: OrderItemDataSource,
-        @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): OrderHistoryRepository =
-        OrderHistoryRepositoryImpl(orderDataSource, orderItemDataSource, coroutineDispatcher)
+    abstract fun provideOrderHistoryRepository(
+        orderHistoryRepositoryImpl: OrderHistoryRepositoryImpl
+    ): OrderHistoryRepository
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideCartRepository(
-        cartDataSource: CartDataSource,
-        detailDataSource: DetailDataSource,
-        @DefaultDispatcher coroutineDispatcher: CoroutineDispatcher
-    ): CartRepository = CartRepositoryImpl(cartDataSource, detailDataSource, coroutineDispatcher)
+    abstract fun provideCartRepository(
+        cartRepositoryImpl: CartRepositoryImpl
+    ): CartRepository
 }

--- a/app/src/main/res/layout/activity_product_detail.xml
+++ b/app/src/main/res/layout/activity_product_detail.xml
@@ -44,8 +44,9 @@
         <ScrollView
             android:id="@+id/sv_product_detail"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/layout_appbar">
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/layout_appbar"
+            app:layout_constraintBottom_toBottomOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/layout_inner"
@@ -343,8 +344,8 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="64dp"
-                    android:background="@color/black"
                     android:orientation="vertical"
+                    android:layout_marginBottom="24dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="@id/gl_end"
                     app:layout_constraintStart_toStartOf="@id/gl_begin"


### PR DESCRIPTION
## 📌  Related Issue
<!-- 관련 이슈를 설명해주세요. -->
- #195 

## 📝  What's-New
<!-- 한 일들을 적어주세요. -->
- [x] `ApiModule`: @Provides 유지하되, GsonConverterFactory provide 메서드 추가
- [x] `DatabaseModule`: 변화 없음
- [x] `DataSourceModule`: @Binds 로 변경
- [x] `RepositoryModule`: @Binds 로 변경
- [x] `CoroutineModule`: 변화 없음

### 참고사항
**`ApiModule`**, **`DatabaseModule`** 의 경우 각각 Retrofit, Room에 대한 의존성을 갖는 `Service`, `Dao`와 연관되기 때문에, @Binds로 구현할 수 없었네. 왜냐면 해당 인터페이스의 구현체를 넘겨줄 수 없었거든.
하지만 **`DataSourceModule`**, **`RepositoryModule`**은 달랐네. 우리가 정의한 인터페이스이고, 우리가 구현한 구현체기 때문이야. 그래서 @Binds 로 구현을 변경했네. @Binds 를 사용했을 때 @Provides를 사용한 경우보다 코드가 더 간결해진 것 같아 좋더군. 하지만 내부적으로 조금 더 딥 다이브 해볼 필요는 느꼈네. 뭔가 그냥 코드만 봤을 때, 더 간결하다는 느낌은 받긴 했네.

close #195 